### PR TITLE
Implement task claiming and spawn evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ organism in the hive:
 - **Hierarchical Memory** – data storage structured as Hive → Cluster → Colony → Creep
 - **Logging** – colorised and severity‑based output drawn by `console.console.js`
 - **Spawn Manager** – plans and queues creeps according to demand
-- **Hierarchical Task Management** – adaptive objectives from hive down to single creep (`manager.htm.js`)
+- **Hierarchical Task Management** – adaptive objectives from hive down to single creep (`manager.htm.js`), supports task quantities and claim cooldowns
 - **HiveMind** – evaluates game state, queues HTM tasks and issues panic spawn orders
 - **Hive's Gaze** – scans the map for threats and opportunities
 - **Movement System** – pathing via Traveler 2.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ organism in the hive:
 - **Hierarchical Memory** – data storage structured as Hive → Cluster → Colony → Creep
 - **Logging** – colorised and severity‑based output drawn by `console.console.js`
 - **Spawn Manager** – plans and queues creeps according to demand
-- **Task Management** – adaptive objectives from hive down to single creep
+- **Hierarchical Task Management** – adaptive objectives from hive down to single creep (`manager.htm.js`)
+- **HiveMind** – evaluates game state, queues HTM tasks and issues panic spawn orders
 - **Hive's Gaze** – scans the map for threats and opportunities
 - **Movement System** – pathing via Traveler 2.0
 - **Console Stats** – ASCII dashboard for CPU and room status
@@ -63,5 +64,6 @@ Next step: focus on the hierarchical task system so the scheduler can trigger co
 - [Logger](./docs/logger.md)
 - [Scheduler](./docs/scheduler.md)
 - [HTM](./docs/htm.md)
+- [HiveMind](./docs/hivemind.md)
 - [Console Stats](./docs/console.md)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ organism in the hive:
 - **Logging** – colorised and severity‑based output drawn by `console.console.js`
 - **Spawn Manager** – plans and queues creeps according to demand
 - **Hierarchical Task Management** – adaptive objectives from hive down to single creep (`manager.htm.js`), supports task quantities and claim cooldowns
-- **HiveMind** – evaluates game state, queues HTM tasks and issues panic spawn orders
+- **HiveMind** – modular decision layer that queues HTM tasks; a subconscious
+  triggers modules like the spawn planner on demand
 - **Hive's Gaze** – scans the map for threats and opportunities
 - **Movement System** – pathing via Traveler 2.0
 - **Console Stats** – ASCII dashboard for CPU and room status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,11 +47,14 @@
 - [x] Task cache: “what was already attempted?” – *Prio 3*
 - [x] Basic skeleton with scheduler hook
 - [x] Basic HiveMind decision module queues tasks
+- [x] Task claiming with cooldown and amount tracking
+- [x] Dynamic miner evaluation based on room energy
 
 ### ✅ Spawn Manager (Prio 4)
 - [ ] Spawn queue with priority and timing
 - [ ] Scheduled pre-spawn logic (e.g. “Miner in 80 ticks”)
 - [x] Integrated with HTM task requests
+- [x] Processes HTM spawn tasks with cooldown estimates
 - [ ] Multi-room spawn and remote queue support
 - [x] Panic mode: minimum creep fallback during total loss – *Prio 5*
 - [ ] Visual/debug marker for pending spawn queue – *Prio 2*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,7 @@
 - [x] Basic HiveMind decision module queues tasks
 - [x] Task claiming with cooldown and amount tracking
 - [x] Dynamic miner evaluation based on room energy
+- [x] Modular HiveMind with spawn and subconscious modules
 
 ### ✅ Spawn Manager (Prio 4)
 - [ ] Spawn queue with priority and timing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,17 +41,19 @@
 - [ ] **Cluster-level**: coordinate HQ and remotes
 - [ ] **Colony-level**: energy balance, building, defense
 - [ ] **Creep-level**: role control, dynamic reassignment
-- [ ] Task priority aging / decay system
-- [ ] Scheduler integration: tasks executed on time
+- [x] Task priority aging / decay system
+- [x] Scheduler integration: tasks executed on time
 - [ ] Log differences between planned/active tasks
-- [ ] Task cache: “what was already attempted?” – *Prio 3*
+- [x] Task cache: “what was already attempted?” – *Prio 3*
+- [x] Basic skeleton with scheduler hook
+- [x] Basic HiveMind decision module queues tasks
 
 ### ✅ Spawn Manager (Prio 4)
 - [ ] Spawn queue with priority and timing
 - [ ] Scheduled pre-spawn logic (e.g. “Miner in 80 ticks”)
-- [ ] Integrated with HTM task requests
+- [x] Integrated with HTM task requests
 - [ ] Multi-room spawn and remote queue support
-- [ ] Panic mode: minimum creep fallback during total loss – *Prio 5*
+- [x] Panic mode: minimum creep fallback during total loss – *Prio 5*
 - [ ] Visual/debug marker for pending spawn queue – *Prio 2*
 
 ### ✅ Building Manager (Prio 3)

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -2,7 +2,8 @@
 
 The HiveMind module serves as the brain of the swarm. It examines the current
 state of each owned room and queues tasks into the Hierarchical Task Management
-(HTM) system.
+(HTM) system. Logic is split into **modules** so each concern can evaluate
+independently.
 
 ## Responsibilities
 
@@ -18,6 +19,12 @@ scheduler.addTask('hivemind', 1, () => hivemind.run());
 ```
 
 This lightweight decision layer can be expanded with more complex strategies
-over time. If a colony has no creeps, the HiveMind queues a `spawnBootstrap`
-task. Miner spawns are determined dynamically based on room energy capacity and
-the number of available mining positions.
+over time. The default `spawn` module handles panic bootstrap and miner
+evaluation. A small “subconscious” checks each tick and only runs a module when
+its queue is empty.
+
+## Modules
+
+- **spawn** – Handles panic bootstrap and miner demand. Converts room state into
+  HTM tasks consumed by the `spawnManager`.
+  Modules can be added later for building, defense or expansion logic.

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -1,0 +1,23 @@
+# 👁️ HiveMind
+
+The HiveMind module serves as the brain of the swarm. It examines the current
+state of each owned room and queues tasks into the Hierarchical Task Management
+(HTM) system.
+
+## Responsibilities
+
+- Analyse rooms for threats or opportunities
+- Push colony level tasks such as `defendRoom` or `upgradeController`
+- Queue spawn orders for the `spawnManager`, including panic bootstrap tasks
+- Keep logic isolated from task execution by delegating to HTM
+
+## Example Usage
+```javascript
+const hivemind = require('manager.hivemind');
+scheduler.addTask('hivemind', 1, () => hivemind.run());
+```
+
+This lightweight decision layer can be expanded with more complex strategies
+over time. It currently also performs a basic spawn evaluation: if a colony
+has no creeps the HiveMind queues a `spawnBootstrap` task. It will also request
+enough miner creeps for each energy source in the room.

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -18,6 +18,6 @@ scheduler.addTask('hivemind', 1, () => hivemind.run());
 ```
 
 This lightweight decision layer can be expanded with more complex strategies
-over time. It currently also performs a basic spawn evaluation: if a colony
-has no creeps the HiveMind queues a `spawnBootstrap` task. It will also request
-enough miner creeps for each energy source in the room.
+over time. If a colony has no creeps, the HiveMind queues a `spawnBootstrap`
+task. Miner spawns are determined dynamically based on room energy capacity and
+the number of available mining positions.

--- a/docs/htm.md
+++ b/docs/htm.md
@@ -47,10 +47,13 @@ htm.addColonyTask('W1N1', 'buildExtensions', { amount: 5 }, 2);
 ### Claiming tasks
 
 Managers use `claimTask` once they pick up an order. The `amount` value is
-decreased and the task is removed when it reaches zero.
+decreased and the task is removed when it reaches zero. The call accepts an
+additional `expectedTicks` parameter so the HiveMind can wait for long running
+actions (like spawning) before re-issuing the task.
 
 ```javascript
-htm.claimTask(htm.LEVELS.COLONY, 'W1N1', 'spawnMiner', 'spawnManager', 10);
+// parameters: level, id, name, manager, baseCooldown, expectedTicks
+htm.claimTask(htm.LEVELS.COLONY, 'W1N1', 'spawnMiner', 'spawnManager', 15, 150);
 ```
 
 `claimedUntil` blocks the HiveMind from requeueing the same task for a few

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -17,6 +17,7 @@ const scheduler = require('scheduler');
 
 scheduler.addTask('logCpu', 5, cpuLogger, { highPriority: true });
 scheduler.addTask('newRoom', 0, analyseRoom, { event: 'roomSeen' });
+scheduler.addTask('htmRun', 1, () => htm.run());
 ```
 
 ## Execution Cycle

--- a/main.js
+++ b/main.js
@@ -16,6 +16,8 @@ const memoryManager = require("manager.memory");
 const pathfinderManager = require("manager.pathfinder");
 const scheduler = require("scheduler");
 const logger = require("./logger");
+const htm = require("manager.htm");
+const hivemind = require("manager.hivemind");
 
 // Initialize the traffic manager
 trafficManager.init();
@@ -97,6 +99,16 @@ scheduler.addTask("buildInfrastructure", 0, () => {
     const room = Game.rooms[roomName];
     buildingManager.buildInfrastructure(room);
   }
+});
+
+// Decision making layer feeding tasks into HTM
+scheduler.addTask("hivemind", 1, () => {
+  hivemind.run();
+});
+
+// Core HTM execution task
+scheduler.addTask("htmRun", 1, () => {
+  htm.run();
 });
 
 module.exports.loop = function () {

--- a/manager.hivemind.js
+++ b/manager.hivemind.js
@@ -1,23 +1,9 @@
 const htm = require('./manager.htm');
-const logger = require('./logger');
-const spawnQueue = require('./manager.spawnQueue');
-const dna = require('./manager.dna');
+const spawnModule = require('./manager.hivemind.spawn');
+
+const modules = [spawnModule];
 
 const hivemind = {
-  /**
-   * Check if a task already exists in the specified HTM container.
-   * @param {string} level - HTM level to search.
-   * @param {string} id - Identifier for the container.
-   * @param {string} name - Task name.
-   * @returns {boolean} True if the task is present.
-   */
-  _taskExists(level, id, name, manager = null) {
-    const container = htm._getContainer(level, id);
-    if (!container || !container.tasks) return false;
-    return container.tasks.some(
-      (t) => t.name === name && (!manager || t.manager === manager),
-    );
-  },
 
   /**
    * Evaluate the hive each tick and queue tasks into the HTM.
@@ -29,98 +15,10 @@ const hivemind = {
       const room = Game.rooms[roomName];
       if (!room.controller || !room.controller.my) continue;
 
-      // Request defense if hostiles are detected
-      const hostileCount = room.find(FIND_HOSTILE_CREEPS).length;
-      if (
-        hostileCount > 0 &&
-        !this._taskExists(htm.LEVELS.COLONY, roomName, 'defendRoom')
-      ) {
-        htm.addColonyTask(
-          roomName,
-          'defendRoom',
-          { count: hostileCount },
-          1,
-          20,
-        );
-        logger.log('hivemind', `Queued defendRoom for ${roomName}`, 2);
-      }
-
-      // Panic evaluation: if no creeps remain, request a bootstrap worker
-      const myCreeps = _.filter(Game.creeps, (c) => c.my && c.room.name === roomName);
-      if (
-        myCreeps.length === 0 &&
-        !this._taskExists(htm.LEVELS.COLONY, roomName, 'spawnBootstrap', 'spawnManager')
-      ) {
-        htm.addColonyTask(
-          roomName,
-          'spawnBootstrap',
-          { role: 'allPurpose', panic: true },
-          0,
-          20,
-          1,
-          'spawnManager',
-        );
-        logger.log('hivemind', `Queued bootstrap spawn for ${roomName}`, 2);
-      }
-
-      // Request miners based on available energy and mining spots
-      const sources = room.find(FIND_SOURCES);
-      let minersNeeded = 0;
-      const minerBody = dna.getBodyParts('miner', room);
-      const workParts = minerBody.filter((p) => p === WORK).length;
-      const harvestPerTick = workParts * HARVEST_POWER;
-
-      for (const source of sources) {
-        const positions =
-          Memory.rooms[roomName]?.miningPositions?.[source.id]?.positions;
-        if (!positions) continue;
-        const maxMiners = Math.min(
-          Object.keys(positions).length,
-          Math.ceil(10 / harvestPerTick),
-        );
-        const live = _.filter(
-          Game.creeps,
-          (c) => c.memory.role === 'miner' && c.memory.source === source.id,
-        ).length;
-        const queued = spawnQueue.queue.filter(
-          (req) =>
-            req.memory.role === 'miner' &&
-            req.memory.source === source.id &&
-            req.room === roomName,
-        ).length;
-        minersNeeded += Math.max(0, maxMiners - live - queued);
-      }
-
-      const existing = htm._getContainer(htm.LEVELS.COLONY, roomName)?.tasks.find(
-        (t) => t.name === 'spawnMiner' && t.manager === 'spawnManager',
-      );
-      if (minersNeeded > 0) {
-        if (existing) {
-          if (existing.amount < minersNeeded) {
-            existing.amount = minersNeeded;
-            logger.log('hivemind', `Updated miner task amount to ${minersNeeded} for ${roomName}`, 2);
-          }
-        } else {
-          htm.addColonyTask(
-            roomName,
-            'spawnMiner',
-            { role: 'miner' },
-            1,
-            30,
-            minersNeeded,
-            'spawnManager',
-          );
-          logger.log('hivemind', `Queued ${minersNeeded} miner spawn(s) for ${roomName}`, 2);
+      for (const mod of modules) {
+        if (!mod.shouldRun || mod.shouldRun(room)) {
+          mod.run(room);
         }
-      }
-
-      // Encourage upgrading when energy is abundant
-      if (
-        room.energyAvailable > room.energyCapacityAvailable * 0.8 &&
-        !this._taskExists(htm.LEVELS.COLONY, roomName, 'upgradeController')
-      ) {
-        htm.addColonyTask(roomName, 'upgradeController', {}, 3, 50);
-        logger.log('hivemind', `Queued upgradeController for ${roomName}`, 2);
       }
     }
   },

--- a/manager.hivemind.js
+++ b/manager.hivemind.js
@@ -1,0 +1,99 @@
+const htm = require('./manager.htm');
+const logger = require('./logger');
+
+const hivemind = {
+  /**
+   * Check if a task already exists in the specified HTM container.
+   * @param {string} level - HTM level to search.
+   * @param {string} id - Identifier for the container.
+   * @param {string} name - Task name.
+   * @returns {boolean} True if the task is present.
+   */
+  _taskExists(level, id, name, manager = null) {
+    const container = htm._getContainer(level, id);
+    if (!container || !container.tasks) return false;
+    return container.tasks.some(
+      (t) => t.name === name && (!manager || t.manager === manager),
+    );
+  },
+
+  /**
+   * Evaluate the hive each tick and queue tasks into the HTM.
+   * Decisions here remain simple but can be expanded later.
+   */
+  run() {
+    htm.init();
+    for (const roomName in Game.rooms) {
+      const room = Game.rooms[roomName];
+      if (!room.controller || !room.controller.my) continue;
+
+      // Request defense if hostiles are detected
+      const hostileCount = room.find(FIND_HOSTILE_CREEPS).length;
+      if (
+        hostileCount > 0 &&
+        !this._taskExists(htm.LEVELS.COLONY, roomName, 'defendRoom')
+      ) {
+        htm.addColonyTask(
+          roomName,
+          'defendRoom',
+          { count: hostileCount },
+          1,
+          20,
+        );
+        logger.log('hivemind', `Queued defendRoom for ${roomName}`, 2);
+      }
+
+      // Panic evaluation: if no creeps remain, request a bootstrap worker
+      const myCreeps = _.filter(Game.creeps, (c) => c.my && c.room.name === roomName);
+      if (
+        myCreeps.length === 0 &&
+        !this._taskExists(htm.LEVELS.COLONY, roomName, 'spawnBootstrap', 'spawnManager')
+      ) {
+        htm.addColonyTask(
+          roomName,
+          'spawnBootstrap',
+          { role: 'allPurpose', panic: true },
+          0,
+          20,
+          1,
+          'spawnManager',
+        );
+        logger.log('hivemind', `Queued bootstrap spawn for ${roomName}`, 2);
+      }
+
+      // Request miners equal to the number of sources
+      const sources = room.find(FIND_SOURCES);
+      const miners = _.filter(
+        Game.creeps,
+        (c) => c.memory.role === 'miner' && c.room.name === roomName,
+      ).length;
+      const minersNeeded = sources.length - miners;
+      if (
+        minersNeeded > 0 &&
+        !this._taskExists(htm.LEVELS.COLONY, roomName, 'spawnMiner', 'spawnManager')
+      ) {
+        htm.addColonyTask(
+          roomName,
+          'spawnMiner',
+          { role: 'miner' },
+          1,
+          30,
+          minersNeeded,
+          'spawnManager',
+        );
+        logger.log('hivemind', `Queued ${minersNeeded} miner spawn(s) for ${roomName}`, 2);
+      }
+
+      // Encourage upgrading when energy is abundant
+      if (
+        room.energyAvailable > room.energyCapacityAvailable * 0.8 &&
+        !this._taskExists(htm.LEVELS.COLONY, roomName, 'upgradeController')
+      ) {
+        htm.addColonyTask(roomName, 'upgradeController', {}, 3, 50);
+        logger.log('hivemind', `Queued upgradeController for ${roomName}`, 2);
+      }
+    }
+  },
+};
+
+module.exports = hivemind;

--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -1,0 +1,112 @@
+const htm = require('./manager.htm');
+const logger = require('./logger');
+const spawnQueue = require('./manager.spawnQueue');
+const dna = require('./manager.dna');
+
+const taskExists = (roomName, name, manager = null) => {
+  const container = htm._getContainer(htm.LEVELS.COLONY, roomName);
+  if (!container || !container.tasks) return false;
+  return container.tasks.some(
+    (t) => t.name === name && (!manager || t.manager === manager),
+  );
+};
+
+const spawnModule = {
+  /** Check if this module should run this tick for the given room */
+  shouldRun(room) {
+    const count = spawnQueue.queue.filter((q) => q.room === room.name).length;
+    return count === 0;
+  },
+
+  /** Analyse room state and queue spawn related tasks in HTM */
+  run(room) {
+    const roomName = room.name;
+
+    // Defense task on hostiles
+    const hostileCount = room.find(FIND_HOSTILE_CREEPS).length;
+    if (hostileCount > 0 && !taskExists(roomName, 'defendRoom')) {
+      htm.addColonyTask(roomName, 'defendRoom', { count: hostileCount }, 1, 20);
+      logger.log('hivemind.spawn', `Queued defendRoom for ${roomName}`, 2);
+    }
+
+    // Panic: no creeps present
+    const myCreeps = _.filter(Game.creeps, (c) => c.my && c.room.name === roomName);
+    if (
+      myCreeps.length === 0 &&
+      !taskExists(roomName, 'spawnBootstrap', 'spawnManager')
+    ) {
+      htm.addColonyTask(
+        roomName,
+        'spawnBootstrap',
+        { role: 'allPurpose', panic: true },
+        0,
+        20,
+        1,
+        'spawnManager',
+      );
+      logger.log('hivemind.spawn', `Queued bootstrap spawn for ${roomName}`, 2);
+    }
+
+    // Determine miner demand based on mining positions and energy
+    const sources = room.find(FIND_SOURCES);
+    let minersNeeded = 0;
+    const minerBody = dna.getBodyParts('miner', room);
+    const workParts = minerBody.filter((p) => p === WORK).length;
+    const harvestPerTick = workParts * HARVEST_POWER;
+
+    for (const source of sources) {
+      const positions = Memory.rooms[roomName]?.miningPositions?.[source.id]?.positions;
+      if (!positions) continue;
+      const maxMiners = Math.min(
+        Object.keys(positions).length,
+        Math.ceil(10 / harvestPerTick),
+      );
+      const live = _.filter(
+        Game.creeps,
+        (c) => c.memory.role === 'miner' && c.memory.source === source.id,
+      ).length;
+      const queued = spawnQueue.queue.filter(
+        (req) =>
+          req.memory.role === 'miner' &&
+          req.memory.source === source.id &&
+          req.room === roomName,
+      ).length;
+      minersNeeded += Math.max(0, maxMiners - live - queued);
+    }
+
+    const existing = htm
+      ._getContainer(htm.LEVELS.COLONY, roomName)?.tasks.find(
+        (t) => t.name === 'spawnMiner' && t.manager === 'spawnManager',
+      );
+    if (minersNeeded > 0) {
+      if (existing) {
+        if (existing.amount < minersNeeded) {
+          existing.amount = minersNeeded;
+          logger.log('hivemind.spawn', `Updated miner task amount to ${minersNeeded} for ${roomName}`, 2);
+        }
+      } else {
+        htm.addColonyTask(
+          roomName,
+          'spawnMiner',
+          { role: 'miner' },
+          1,
+          30,
+          minersNeeded,
+          'spawnManager',
+        );
+        logger.log('hivemind.spawn', `Queued ${minersNeeded} miner spawn(s) for ${roomName}`, 2);
+      }
+    }
+
+    // Encourage upgrades when energy is abundant
+    if (
+      room.energyAvailable > room.energyCapacityAvailable * 0.8 &&
+      !taskExists(roomName, 'upgradeController')
+    ) {
+      htm.addColonyTask(roomName, 'upgradeController', {}, 3, 50);
+      logger.log('hivemind.spawn', `Queued upgradeController for ${roomName}`, 2);
+    }
+  },
+};
+
+module.exports = spawnModule;

--- a/manager.htm.js
+++ b/manager.htm.js
@@ -1,0 +1,261 @@
+const logger = require('./logger');
+
+const DEFAULT_TASK_TTL = 100;
+// Default cooldown ticks after a task is claimed. HiveMind will not requeue the
+// same task until this expires.
+const DEFAULT_CLAIM_COOLDOWN = 5;
+
+const HTM_LEVELS = {
+  HIVE: 'hive',
+  CLUSTER: 'cluster',
+  COLONY: 'colony',
+  CREEP: 'creep',
+};
+
+const htm = {
+  /** Ensure the HTM memory structure exists */
+  init() {
+    if (!Memory.htm) {
+      Memory.htm = {
+        hive: { tasks: [] },
+        clusters: {},
+        colonies: {},
+        creeps: {},
+      };
+    }
+  },
+
+  /**
+   * Check if a given container already has a task with the name.
+   * @param {string} level - Level of the task container.
+   * @param {string} id - Identifier for the container.
+   * @param {string} name - Task name to look for.
+   * @returns {boolean} True if a task exists.
+   */
+  hasTask(level, id, name, manager) {
+    const container = this._getContainer(level, id);
+    if (!container || !container.tasks) return false;
+    return container.tasks.some(
+      (t) => t.name === name && (!manager || t.manager === manager),
+    );
+  },
+
+  /**
+   * Register a task handler for a specific level and task name.
+   * Handlers can be used to execute logic when tasks are processed.
+   */
+  registerHandler(level, name, handler) {
+    if (!this.handlers) this.handlers = {};
+    if (!this.handlers[level]) this.handlers[level] = {};
+    this.handlers[level][name] = handler;
+  },
+
+  /** Add a new task to the hive level */
+  addHiveTask(
+    name,
+    data = {},
+    priority = 1,
+    ttl = DEFAULT_TASK_TTL,
+    amount = 1,
+    manager = null,
+  ) {
+    this._addTask(
+      HTM_LEVELS.HIVE,
+      'hive',
+      name,
+      data,
+      priority,
+      ttl,
+      amount,
+      manager,
+    );
+  },
+
+  /** Add a new task to a cluster */
+  addClusterTask(
+    clusterId,
+    name,
+    data = {},
+    priority = 1,
+    ttl = DEFAULT_TASK_TTL,
+    amount = 1,
+    manager = null,
+  ) {
+    if (!Memory.htm.clusters[clusterId]) Memory.htm.clusters[clusterId] = { tasks: [] };
+    this._addTask(
+      HTM_LEVELS.CLUSTER,
+      clusterId,
+      name,
+      data,
+      priority,
+      ttl,
+      amount,
+      manager,
+    );
+  },
+
+  /** Add a new task to a colony */
+  addColonyTask(
+    colonyId,
+    name,
+    data = {},
+    priority = 1,
+    ttl = DEFAULT_TASK_TTL,
+    amount = 1,
+    manager = null,
+  ) {
+    if (!Memory.htm.colonies[colonyId]) Memory.htm.colonies[colonyId] = { tasks: [] };
+    this._addTask(
+      HTM_LEVELS.COLONY,
+      colonyId,
+      name,
+      data,
+      priority,
+      ttl,
+      amount,
+      manager,
+    );
+  },
+
+  /** Add a new task to a creep */
+  addCreepTask(
+    creepName,
+    name,
+    data = {},
+    priority = 1,
+    ttl = DEFAULT_TASK_TTL,
+    amount = 1,
+    manager = null,
+  ) {
+    if (!Memory.htm.creeps[creepName]) Memory.htm.creeps[creepName] = { tasks: [] };
+    this._addTask(
+      HTM_LEVELS.CREEP,
+      creepName,
+      name,
+      data,
+      priority,
+      ttl,
+      amount,
+      manager,
+    );
+  },
+
+  /**
+   * Mark a task as claimed so HiveMind does not immediately requeue it.
+   * Amount is decreased and the task removed when it reaches zero.
+   *
+   * @param {string} level - HTM level of the task container.
+   * @param {string} id - Identifier for the container.
+   * @param {string} name - Task name to claim.
+   * @param {string|null} manager - Manager claiming the task.
+   * @param {number} cooldown - Ticks until the task can be queued again.
+   */
+  claimTask(level, id, name, manager = null, cooldown = DEFAULT_CLAIM_COOLDOWN) {
+    const container = this._getContainer(level, id);
+    if (!container) return;
+    const task = container.tasks.find(
+      (t) => t.name === name && (!manager || t.manager === manager),
+    );
+    if (!task) return;
+    task.amount -= 1;
+    task.claimedUntil = Game.time + cooldown;
+    if (task.amount <= 0) {
+      const idx = container.tasks.indexOf(task);
+      if (idx !== -1) container.tasks.splice(idx, 1);
+    }
+  },
+
+  /** Main processing entry triggered by the scheduler each tick */
+  run() {
+    this.init();
+    this._processLevel(HTM_LEVELS.HIVE, 'hive');
+    for (const clusterId in Memory.htm.clusters) {
+      this._processLevel(HTM_LEVELS.CLUSTER, clusterId);
+    }
+    for (const colonyId in Memory.htm.colonies) {
+      this._processLevel(HTM_LEVELS.COLONY, colonyId);
+    }
+    for (const creepName in Memory.htm.creeps) {
+      this._processLevel(HTM_LEVELS.CREEP, creepName);
+    }
+  },
+
+  // --- Internal helpers ---
+
+  _addTask(level, id, name, data, priority, ttl, amount = 1, manager = null) {
+    const task = {
+      name,
+      data,
+      priority,
+      ttl,
+      age: 0,
+      amount,
+      manager,
+      claimedUntil: 0,
+    };
+    const container = this._getContainer(level, id);
+    if (!this.hasTask(level, id, name, manager)) {
+      container.tasks.push(task);
+      logger.log('HTM', `Added ${level} task ${name} (${id})`, 2);
+    }
+  },
+
+  _processLevel(level, id) {
+    const container = this._getContainer(level, id);
+    if (!container || !container.tasks) return;
+
+    // Age tasks and remove expired ones
+    for (let i = container.tasks.length - 1; i >= 0; i--) {
+      const task = container.tasks[i];
+      task.age += 1;
+      if (task.age >= task.ttl) {
+        container.tasks.splice(i, 1);
+        logger.log('HTM', `Removed expired ${level} task ${task.name} (${id})`, 3);
+        continue;
+      }
+      if (task.amount <= 0) {
+        container.tasks.splice(i, 1);
+        continue;
+      }
+    }
+
+    // Sort by priority (lower value = higher priority)
+    container.tasks.sort((a, b) => a.priority - b.priority);
+
+    // Execute tasks that are not claimed
+    for (const task of container.tasks) {
+      if (Game.time < task.claimedUntil) continue;
+      const handler = this.handlers?.[level]?.[task.name];
+      if (typeof handler === 'function') {
+        try {
+          handler(task.data);
+          logger.log('HTM', `Executed ${level} task ${task.name} (${id})`, 2);
+        } catch (err) {
+          logger.log('HTM', `Error executing ${task.name}: ${err}`, 4);
+        }
+      } else {
+        logger.log('HTM', `No handler for ${level} task ${task.name}`, 3);
+      }
+    }
+  },
+
+  _getContainer(level, id) {
+    switch (level) {
+      case HTM_LEVELS.HIVE:
+        return Memory.htm.hive;
+      case HTM_LEVELS.CLUSTER:
+        return Memory.htm.clusters[id];
+      case HTM_LEVELS.COLONY:
+        return Memory.htm.colonies[id];
+      case HTM_LEVELS.CREEP:
+        return Memory.htm.creeps[id];
+      default:
+        return null;
+    }
+  },
+};
+
+// expose constants for external modules
+htm.LEVELS = HTM_LEVELS;
+
+module.exports = htm;


### PR DESCRIPTION
## Summary
- expand HTM tasks with `amount`, `manager` and `claimedUntil`
- add `claimTask` helper and skip claimed tasks
- extend HiveMind to queue panic bootstrap and miner spawn tasks
- allow SpawnManager to process HTM tasks
- document new behaviour in README and docs
- update roadmap to mark progress

## Testing
- `node --check manager.htm.js`
- `node --check manager.hivemind.js`
- `node --check manager.spawn.js`
- `node --check main.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab93a8ac8327b08f58f35cde9e32