### PR TITLE
Fix optional chaining for Screeps compatibility

### DIFF
--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -55,7 +55,14 @@ const spawnModule = {
     const harvestPerTick = workParts * HARVEST_POWER;
 
     for (const source of sources) {
-      const positions = Memory.rooms[roomName]?.miningPositions?.[source.id]?.positions;
+      let positions = null;
+      if (
+        Memory.rooms[roomName] &&
+        Memory.rooms[roomName].miningPositions &&
+        Memory.rooms[roomName].miningPositions[source.id]
+      ) {
+        positions = Memory.rooms[roomName].miningPositions[source.id].positions;
+      }
       if (!positions) continue;
       const maxMiners = Math.min(
         Object.keys(positions).length,
@@ -74,10 +81,12 @@ const spawnModule = {
       minersNeeded += Math.max(0, maxMiners - live - queued);
     }
 
-    const existing = htm
-      ._getContainer(htm.LEVELS.COLONY, roomName)?.tasks.find(
+    const container = htm._getContainer(htm.LEVELS.COLONY, roomName);
+    const existing = container && container.tasks
+      ? container.tasks.find(
         (t) => t.name === 'spawnMiner' && t.manager === 'spawnManager',
-      );
+      )
+      : null;
     if (minersNeeded > 0) {
       if (existing) {
         if (existing.amount < minersNeeded) {

--- a/manager.htm.js
+++ b/manager.htm.js
@@ -234,7 +234,10 @@ const htm = {
     // Execute tasks that are not claimed
     for (const task of container.tasks) {
       if (Game.time < task.claimedUntil) continue;
-      const handler = this.handlers?.[level]?.[task.name];
+      let handler = null;
+      if (this.handlers && this.handlers[level]) {
+        handler = this.handlers[level][task.name];
+      }
       if (typeof handler === 'function') {
         try {
           handler(task.data);


### PR DESCRIPTION
## Summary
- avoid optional chaining syntax in `manager.htm.js`
- avoid optional chaining syntax in `manager.hivemind.spawn.js`

## Testing
- `node -c manager.htm.js`
- `node -c manager.hivemind.spawn.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684364cacdcc83279d0a7046ccfba2e5