### PR TITLE
Finalize HiveTravel refactor and spawn tweaks

### DIFF
--- a/console.debugLogs.js
+++ b/console.debugLogs.js
@@ -3,7 +3,7 @@ const debugConfig = {
   bodyPartManager: false,
   memoryManager: false,
   roleAllPurpose: false,
-  traveler: false,
+  hiveTravel: false,
   roleMiner: false,
   demandManager: false,
   spawnQueue: false,

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -25,6 +25,7 @@ its queue is empty.
 
 ## Modules
 
-- **spawn** – Handles panic bootstrap and miner demand. Converts room state into
-  HTM tasks consumed by the `spawnManager`.
+- **spawn** – Handles panic bootstrap and miner demand. Queues miner and
+  hauler tasks so hauler count automatically scales with available miners.
+  Converts room state into HTM tasks consumed by the `spawnManager`.
   Modules can be added later for building, defense or expansion logic.

--- a/manager.hiveTravel.js
+++ b/manager.hiveTravel.js
@@ -581,7 +581,12 @@ const STATE_CPU = 3;
 const STATE_DEST_X = 4;
 const STATE_DEST_Y = 5;
 const STATE_DEST_ROOMNAME = 6;
-// assigns a function to Creep.prototype: creep.travelTo(destination)
-Creep.prototype.travelTo = function (destination, options) {
-    return Traveler.travelTo(this, destination, options);
-};
+
+// expose travelTo only when Creep exists (e.g. in the Screeps runtime)
+if (typeof Creep !== "undefined" && Creep.prototype) {
+    Creep.prototype.travelTo = function (destination, options) {
+        return Traveler.travelTo(this, destination, options);
+    };
+}
+
+module.exports = Traveler;

--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -158,37 +158,19 @@ const spawnManager = {
    * @param {number} energyCapacityAvailable - The available energy capacity.
    */
   spawnHauler(spawn, room, energyCapacityAvailable) {
-    const currentHaulers = _.filter(
-      Game.creeps,
-      (creep) =>
-        creep.memory.role === "hauler" && creep.room.name === room.name,
-    ).length;
-    const queuedHaulers = spawnQueue.queue.filter(
-      (req) => req.memory.role === "hauler" && req.room === room.name,
-    ).length;
-
-    if (currentHaulers + queuedHaulers < 6) {
-      // Maximum of 6 haulers
-      const bodyParts = dna.getBodyParts("hauler", room);
-      spawnQueue.addToQueue(
-        "hauler",
-        room.name,
-        bodyParts,
-        { role: "hauler" },
-        spawn.id,
-      );
-      logger.log(
-        "spawnManager",
-        `Added hauler creep to spawn queue in room ${room.name}`,
-        2,
-      );
-    } else {
-      logger.log(
-        "spawnManager",
-        `Maximum number of haulers reached for room ${room.name}`,
-        2,
-      );
-    }
+    const bodyParts = dna.getBodyParts("hauler", room);
+    spawnQueue.addToQueue(
+      "hauler",
+      room.name,
+      bodyParts,
+      { role: "hauler" },
+      spawn.id,
+    );
+    logger.log(
+      "spawnManager",
+      `Added hauler creep to spawn queue in room ${room.name}`,
+      2,
+    );
   },
 
 


### PR DESCRIPTION
## Summary
- guard HiveTravel prototype injection for non-Screeps environments
- remove hauler cap to let HiveMind control quantity
- rename traveler debug flag to `hiveTravel`
- document hauler scaling in HiveMind docs

## Testing
- `NODE_PATH=. node -e "global.Game={rooms:{},creeps:{},cpu:{getUsed:()=>0,limit:0,bucket:0}};global.Memory={};global.Creep=function(){};global.RoomPosition=function(){};require('./main.js')"`
- `NODE_PATH=. node -e "global.Game={rooms:{},creeps:{},cpu:{getUsed:()=>0,limit:0,bucket:0}};global.Memory={};global.Creep=function(){};global.RoomPosition=function(){};require('./manager.hivemind.spawn.js')"`
- `NODE_PATH=. node -e "global.Game={rooms:{},creeps:{},cpu:{getUsed:()=>0,limit:0,bucket:0}};global.Memory={};global.Creep=function(){};global.RoomPosition=function(){};require('./manager.hiveTravel.js')"`


------
https://chatgpt.com/codex/tasks/task_e_6843792a1ce88327a506e43a91e0a2ad