### PR TITLE
Add HUD visualizer module and toggle

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,12 @@ const hivemind = require("manager.hivemind");
 let myStats = [];
 global.visualizeDT = false;
 
+// Ensure persistent settings exist
+if (!Memory.settings) Memory.settings = {};
+if (Memory.settings.enableVisuals === undefined) {
+  Memory.settings.enableVisuals = true;
+}
+
 global.visual = {
   DT: function (toggle) {
     if (toggle === 1) {
@@ -33,6 +39,18 @@ global.visual = {
       console.log("Distance Transform Visualization: OFF");
     } else {
       console.log("Usage: visual.DT(1) to show, visual.DT(0) to hide");
+    }
+  },
+  overlay: function (toggle) {
+    if (!Memory.settings) Memory.settings = {};
+    if (toggle === 1) {
+      Memory.settings.enableVisuals = true;
+      console.log("HUD visuals: ON");
+    } else if (toggle === 0) {
+      Memory.settings.enableVisuals = false;
+      console.log("HUD visuals: OFF");
+    } else {
+      console.log("Usage: visual.overlay(1) to show, visual.overlay(0) to hide");
     }
   },
 };

--- a/manager.hud.js
+++ b/manager.hud.js
@@ -1,13 +1,36 @@
 // hudManager.js
+const visualizer = require("manager.visualizer");
 
 module.exports = {
   createHUD: function (room) {
-    const visual = new RoomVisual(room.name);
+    if (!visualizer.enabled) return;
 
-    // Distance Transform Status
-    const dtStatus = room.memory.distanceTransform ? "✓" : "X";
-    visual.text(`DT: ${dtStatus}`, 1, 1, { color: "white", font: 1 });
+    // Controller level near controller
+    if (room.controller) {
+      visualizer.showInfo([`RCL: ${room.controller.level}`], {
+        room: room,
+        pos: room.controller.pos,
+      });
+    }
 
-    // Add more statuses as needed
+    // Mark energy sources
+    const sources = room.find(FIND_SOURCES);
+    for (const source of sources) {
+      visualizer.circle(source.pos, "yellow");
+    }
+
+    // Task summary for this colony
+    const tasks =
+      (Memory.htm &&
+        Memory.htm.colonies &&
+        Memory.htm.colonies[room.name] &&
+        Memory.htm.colonies[room.name].tasks) || [];
+    const taskLines = tasks.map((t) => `${t.name} (${t.amount})`);
+    if (taskLines.length > 0) {
+      visualizer.showInfo(taskLines, {
+        room: room,
+        pos: new RoomPosition(1, 1, room.name),
+      });
+    }
   },
 };

--- a/manager.visualizer.js
+++ b/manager.visualizer.js
@@ -1,0 +1,68 @@
+const Visualizer = {
+  get enabled() {
+    return Memory.settings && Memory.settings.enableVisuals;
+  },
+
+  circle(pos, color = 'red', opts = {}) {
+    if (!this.enabled) return;
+    _.defaults(opts, { fill: color, radius: 0.35, opacity: 0.5 });
+    new RoomVisual(pos.roomName).circle(pos.x, pos.y, opts);
+  },
+
+  drawLayout(layout, anchor, opts = {}) {
+    if (!this.enabled) return;
+    _.defaults(opts, { opacity: 0.5 });
+    const vis = new RoomVisual(anchor.roomName);
+    for (const type in layout) {
+      for (const pos of layout[type]) {
+        vis.structure(anchor.x + pos.x, anchor.y + pos.y, type, opts);
+      }
+    }
+    vis.connectRoads(opts);
+  },
+
+  drawRoads(positions) {
+    if (!this.enabled) return;
+    const byRoom = _.groupBy(positions, (p) => p.roomName);
+    for (const roomName in byRoom) {
+      const vis = new RoomVisual(roomName);
+      for (const pos of byRoom[roomName]) {
+        vis.structure(pos.x, pos.y, STRUCTURE_ROAD);
+      }
+      vis.connectRoads();
+    }
+  },
+
+  showInfo(lines, origin, opts = {}) {
+    if (!this.enabled) return;
+    const pos = origin.pos || origin;
+    const roomName = pos.roomName || (origin.room && origin.room.name);
+    const vis = new RoomVisual(roomName);
+    if (!Array.isArray(lines)) lines = [String(lines)];
+    lines.forEach((line, i) => vis.text(line, pos.x, pos.y + i, opts));
+  },
+
+  barGraph(progress, pos, width = 7, scale = 1) {
+    if (!this.enabled) return;
+    const vis = new RoomVisual(pos.roomName);
+    let percent;
+    if (Array.isArray(progress)) {
+      percent = progress[0] / progress[1];
+    } else {
+      percent = progress;
+    }
+    const height = 0.8 * scale;
+    vis.rect(pos.x, pos.y - height, width, height, { stroke: '#ffffff', opacity: 0.3 });
+    vis.rect(pos.x, pos.y - height, width * percent, height, { fill: '#ffffff', opacity: 0.6, strokeWidth: 0 });
+    const text = Array.isArray(progress)
+      ? `${progress[0]}/${progress[1]}`
+      : `${Math.round(percent * 100)}%`;
+    vis.text(text, pos.x + width / 2, pos.y - height / 2, {
+      color: '#ffffff',
+      align: 'center',
+      font: `${0.8 * scale} Trebuchet MS`,
+    });
+  },
+};
+
+module.exports = Visualizer;


### PR DESCRIPTION
## Summary
- implement `manager.visualizer.js` with helpers to render room overlays
- visualize controller level, sources and tasks via `manager.hud.js`
- add overlay toggle in `main.js` respecting `Memory.settings.enableVisuals`
- initialize default visual settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684450644f708327a89b489526ea0299