### PR TITLE
Enhance scheduler with CPU-aware tasks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,8 +12,8 @@
 - [ ] Internal tick counter for global timing
 - [ ] Safe execution with error isolation
 - [x] Dynamic registration via `addTask(...)`
-- [ ] Runs logger, stats display, and future HTM triggers
-- [ ] Optional debug toggle to list active/queued tasks – *Prio 2*
+- [x] Runs logger, stats display, and future HTM triggers
+- [x] Optional debug toggle to list active/queued tasks – *Prio 2*
 
 ### ✅ Logging (Prio 5)
 - [ ] `logger.log(message, severity, roomName, duration)`

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -10,6 +10,8 @@ The scheduler coordinates recurring actions and event driven tasks. It ensures m
 
 Tasks can also be flagged as `highPriority` so they execute before normal tasks each tick.
 
+Tasks may specify `minBucket` to delay execution until the CPU bucket is above a certain value. This allows optional logic to throttle itself when the colony is CPU starved.
+
 ## Registering Tasks
 
 ```javascript
@@ -27,3 +29,7 @@ scheduler.addTask('htmRun', 1, () => htm.run());
 3. Any triggered events are processed in FIFO order.
 
 One time tasks are removed after execution. You can force a task to run next tick with `requestTaskUpdate(name)` or run it immediately using `runTaskNow(name)`.
+
+Use `removeTask(name)` to cancel a task entirely or `updateTask(name, interval)` to change its schedule.
+
+Calling `scheduler.listTasks()` returns a summary of upcoming executions which can be printed periodically via `scheduler.logTaskList()`.

--- a/main.js
+++ b/main.js
@@ -28,6 +28,9 @@ if (!Memory.settings) Memory.settings = {};
 if (Memory.settings.enableVisuals === undefined) {
   Memory.settings.enableVisuals = true;
 }
+if (Memory.settings.showTaskList === undefined) {
+  Memory.settings.showTaskList = false;
+}
 
 global.visual = {
   DT: function (toggle) {
@@ -127,6 +130,33 @@ scheduler.addTask("htmRun", 1, () => {
   htm.run();
 });
 
+// Scheduled console drawing
+scheduler.addTask(
+  "consoleDisplay",
+  5,
+  () => {
+    const start = Game.cpu.getUsed();
+    console.log(statsConsole.displayHistogram());
+    console.log(statsConsole.displayStats());
+    console.log(statsConsole.displayLogs());
+    const drawTime = Game.cpu.getUsed() - start;
+    statsConsole.log("Time to Draw: " + drawTime.toFixed(2), 2);
+  },
+  { minBucket: 1000 },
+);
+
+// Debug listing of scheduled tasks
+scheduler.addTask(
+  "showScheduled",
+  50,
+  () => {
+    if (Memory.settings && Memory.settings.showTaskList) {
+      scheduler.logTaskList();
+    }
+  },
+  { minBucket: 0 },
+);
+
 module.exports.loop = function () {
   const startCPU = Game.cpu.getUsed();
 
@@ -212,11 +242,5 @@ module.exports.loop = function () {
     );
   }
 
-  if (Game.time % 5 === 0) {
-    console.log(statsConsole.displayHistogram());
-    console.log(statsConsole.displayStats());
-    console.log(statsConsole.displayLogs());
-    let drawTime = Game.cpu.getUsed() - totalCPUUsage;
-    console.log("Time to Draw: " + drawTime.toFixed(2));
-  }
+  // drawing handled by scheduler
 };

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,6 +1,8 @@
 /**
  * Represents a single scheduled task.
  */
+const statsConsole = require('console.console');
+
 class Task {
   constructor(name, interval, taskFunction, options = {}) {
     this.name = name;
@@ -10,6 +12,7 @@ class Task {
     this.highPriority = options.highPriority || false;
     this.once = options.once || false;
     this.event = options.event || null;
+    this.minBucket = options.minBucket || 0; // Minimum CPU bucket to execute
     this.executed = false; // Track if the task ran at least once
   }
 }
@@ -24,10 +27,25 @@ class Scheduler {
     this.tasks = [];
     /** @type {Task[]} tasks executed before normal tasks */
     this.highPriorityTasks = [];
-    /** @type {Object.<string, Task[]>} tasks listening to events */
+    /** @type {Object.<string, {high: Task[], normal: Task[]}>} event listeners */
     this.eventTasks = {};
     /** @type {Array<{eventName: string, data: any}>} events queued this tick */
     this.triggeredEvents = [];
+  }
+
+  /** Reset all scheduler state (mainly for tests) */
+  reset() {
+    this.tasks = [];
+    this.highPriorityTasks = [];
+    this.eventTasks = {};
+    this.triggeredEvents = [];
+  }
+
+  /** Insert a task into a sorted array by nextRun */
+  _insertTask(task, arr) {
+    let i = arr.findIndex((t) => t.nextRun > task.nextRun);
+    if (i === -1) arr.push(task);
+    else arr.splice(i, 0, task);
   }
 
   /**
@@ -45,12 +63,16 @@ class Scheduler {
     const task = new Task(name, interval, taskFunction, options);
 
     if (task.event) {
-      if (!this.eventTasks[task.event]) this.eventTasks[task.event] = [];
-      this.eventTasks[task.event].push(task);
+      if (!this.eventTasks[task.event])
+        this.eventTasks[task.event] = { high: [], normal: [] };
+      const group = task.highPriority
+        ? this.eventTasks[task.event].high
+        : this.eventTasks[task.event].normal;
+      group.push(task);
     } else if (task.highPriority) {
-      this.highPriorityTasks.push(task);
+      this._insertTask(task, this.highPriorityTasks);
     } else {
-      this.tasks.push(task);
+      this._insertTask(task, this.tasks);
     }
   }
   /**
@@ -59,47 +81,68 @@ class Scheduler {
    */
   run() {
     // --- High priority tasks ---
-    for (const task of this.highPriorityTasks) {
-      if (Game.time >= task.nextRun && (!task.once || !task.executed)) {
+    while (
+      this.highPriorityTasks.length &&
+      Game.time >= this.highPriorityTasks[0].nextRun
+    ) {
+      const task = this.highPriorityTasks.shift();
+      if (Game.cpu.bucket >= task.minBucket && (!task.once || !task.executed)) {
         task.taskFunction();
         task.executed = true;
-        if (!task.once) task.nextRun = Game.time + task.interval;
+        if (!task.once) {
+          task.nextRun = Game.time + Math.max(1, task.interval);
+        }
+      } else {
+        task.nextRun = Game.time + Math.max(1, task.interval);
       }
-    }
-    // Remove completed one-time high priority tasks
-    for (let i = this.highPriorityTasks.length - 1; i >= 0; i--) {
-      if (
-        this.highPriorityTasks[i].once &&
-        this.highPriorityTasks[i].executed
-      ) {
-        this.highPriorityTasks.splice(i, 1);
+      if (!task.once) {
+        this._insertTask(task, this.highPriorityTasks);
       }
     }
 
+    // Remove stale one-time high priority tasks from front
+    while (this.highPriorityTasks.length && this.highPriorityTasks[0].once && this.highPriorityTasks[0].executed) {
+      this.highPriorityTasks.shift();
+    }
+
     // --- Regular interval tasks ---
-    for (const task of this.tasks) {
-      if (Game.time >= task.nextRun && (!task.once || !task.executed)) {
+    while (this.tasks.length && Game.time >= this.tasks[0].nextRun) {
+      const task = this.tasks.shift();
+      if (Game.cpu.bucket >= task.minBucket && (!task.once || !task.executed)) {
         task.taskFunction();
         task.executed = true;
-        if (!task.once) task.nextRun = Game.time + task.interval;
+        if (!task.once) {
+          task.nextRun = Game.time + Math.max(1, task.interval);
+        }
+      } else {
+        // postpone when bucket is low
+        task.nextRun = Game.time + Math.max(1, task.interval);
+      }
+      if (!task.once) {
+        this._insertTask(task, this.tasks);
       }
     }
-    // Remove completed one-time tasks
-    for (let i = this.tasks.length - 1; i >= 0; i--) {
-      if (this.tasks[i].once && this.tasks[i].executed) {
-        this.tasks.splice(i, 1);
-      }
+
+    // Remove stale one-time tasks from front
+    while (this.tasks.length && this.tasks[0].once && this.tasks[0].executed) {
+      this.tasks.shift();
     }
 
     // --- Process triggered events ---
     while (this.triggeredEvents.length > 0) {
       const { eventName, data } = this.triggeredEvents.shift();
-      const listeners = this.eventTasks[eventName] || [];
-      for (let i = listeners.length - 1; i >= 0; i--) {
-        const task = listeners[i];
-        task.taskFunction(data);
-        if (task.once) listeners.splice(i, 1);
-      }
+      const listeners = this.eventTasks[eventName] || { high: [], normal: [] };
+      const processList = (list) => {
+        for (let i = list.length - 1; i >= 0; i--) {
+          const task = list[i];
+          if (Game.cpu.bucket >= task.minBucket) {
+            task.taskFunction(data);
+          }
+          if (task.once) list.splice(i, 1);
+        }
+      };
+      processList(listeners.high);
+      processList(listeners.normal);
     }
   }
 
@@ -112,6 +155,58 @@ class Scheduler {
     if (task) {
       task.taskFunction();
       task.nextRun = Game.time + task.interval;
+    }
+  }
+
+  /** Remove a task completely */
+  removeTask(name) {
+    const removeFrom = (arr) => {
+      const index = arr.findIndex((t) => t.name === name);
+      if (index !== -1) arr.splice(index, 1);
+    };
+    removeFrom(this.tasks);
+    removeFrom(this.highPriorityTasks);
+    for (const evt in this.eventTasks) {
+      removeFrom(this.eventTasks[evt].high);
+      removeFrom(this.eventTasks[evt].normal);
+    }
+  }
+
+  /** Update interval for an existing task */
+  updateTask(name, interval) {
+    const task = this._findTask(name);
+    if (task) {
+      task.interval = interval;
+      task.nextRun = Game.time + interval;
+    }
+  }
+
+  /** Return an array of task summaries */
+  listTasks() {
+    const format = (t) => ({ name: t.name, nextRun: t.nextRun });
+    const events = {};
+    for (const e in this.eventTasks) {
+      events[e] = [
+        ...this.eventTasks[e].high.map(format),
+        ...this.eventTasks[e].normal.map(format),
+      ];
+    }
+    return {
+      high: this.highPriorityTasks.map(format),
+      normal: this.tasks.map(format),
+      events,
+    };
+  }
+
+  /** Log task list via statsConsole */
+  logTaskList() {
+    const list = this.listTasks();
+    const show = (arr) =>
+      arr.map((t) => `${t.name}@${t.nextRun}`).join(', ') || 'none';
+    statsConsole.log(`HP: ${show(list.high)}`, 2);
+    statsConsole.log(`Tasks: ${show(list.normal)}`, 2);
+    for (const e in list.events) {
+      statsConsole.log(`${e}: ${show(list.events[e])}`, 2);
     }
   }
 
@@ -141,7 +236,10 @@ class Scheduler {
       this.highPriorityTasks.find((t) => t.name === name);
     if (task) return task;
     for (const evt in this.eventTasks) {
-      const found = this.eventTasks[evt].find((t) => t.name === name);
+      const ev = this.eventTasks[evt];
+      let found = ev.high.find((t) => t.name === name);
+      if (found) return found;
+      found = ev.normal.find((t) => t.name === name);
       if (found) return found;
     }
     return null;
@@ -149,3 +247,4 @@ class Scheduler {
 }
 
 module.exports = new Scheduler();
+module.exports.Scheduler = Scheduler;

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,0 +1,49 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const { Scheduler } = require('../scheduler');
+
+describe('scheduler', function () {
+  let scheduler;
+
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory();
+    scheduler = new Scheduler();
+  });
+
+  it('executes interval tasks in sorted order', function () {
+    const run = [];
+    scheduler.addTask('a', 2, () => run.push('a'));
+    scheduler.addTask('b', 1, () => run.push('b'));
+
+    for (let i = 0; i < 3; i++) {
+      scheduler.run();
+      Game.time++;
+    }
+
+    expect(run).to.deep.equal(['b', 'a', 'b']);
+  });
+
+  it('respects minBucket for throttling', function () {
+    const run = [];
+    scheduler.addTask('a', 0, () => run.push('a'), { minBucket: 200 });
+    Game.cpu.bucket = 100;
+    scheduler.run();
+    expect(run).to.be.empty;
+    Game.cpu.bucket = 500;
+    Game.time++;
+    scheduler.run();
+    expect(run).to.deep.equal(['a']);
+  });
+
+  it('removes tasks properly', function () {
+    let count = 0;
+    scheduler.addTask('a', 0, () => count++);
+    scheduler.run();
+    expect(count).to.equal(1);
+    scheduler.removeTask('a');
+    Game.time++;
+    scheduler.run();
+    expect(count).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add CPU bucket throttling and prioritized event queues
- support task removal, updates, and listing
- schedule console output and optional task listing via Scheduler
- document new scheduler API and mark roadmap progress
- provide tests for scheduler behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445c0b17cc8327947c72f00f18c43c