### PR TITLE
Add console draw time metric

### DIFF
--- a/console.console.js
+++ b/console.console.js
@@ -111,6 +111,12 @@ var statsConsole = {
       lineStat.push(stat);
     }
 
+    // Display console drawing time after the Total entry when available
+    if (Memory.stats.consoleDrawTime !== undefined) {
+      lineName.push("Console draw time");
+      lineStat.push(Memory.stats.consoleDrawTime.toFixed(2));
+    }
+
     let cpuStats =
       leftTopCorner +
       _.repeat(

--- a/docs/console.md
+++ b/docs/console.md
@@ -8,5 +8,7 @@ The console module renders an ASCII dashboard inside the Screeps client. It comb
 - **Stat Box** – shows GCL progress, room energy and controller status.
 - **Logging Panel** – latest messages from the logger sorted by severity.
 - Customisable characters for borders, bars and spacing.
+- **Console draw time** – CPU cost for rendering the dashboard, shown under the
+  "Total" CPU line.
 
 The scheduler feeds data into the console module every tick. Use `statsConsole.displayStats()` to print the dashboard from the game console when needed.

--- a/main.js
+++ b/main.js
@@ -140,7 +140,9 @@ scheduler.addTask(
     console.log(statsConsole.displayStats());
     console.log(statsConsole.displayLogs());
     const drawTime = Game.cpu.getUsed() - start;
-    statsConsole.log("Time to Draw: " + drawTime.toFixed(2), 2);
+    // Store draw time for displayStats instead of logging each tick
+    if (!Memory.stats) Memory.stats = {};
+    Memory.stats.consoleDrawTime = drawTime;
   },
   { minBucket: 1000 },
 );


### PR DESCRIPTION
## Summary
- remove transient draw time log from `main.js`
- persist draw time to `Memory.stats` for dashboard use
- show "Console draw time" under the CPU total in `displayStats`
- document the new metric in `docs/console.md`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446375298083279d1832e09aa931b5