### PR TITLE
Fix miner DNA and panic spawn handling

### DIFF
--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -26,6 +26,7 @@ its queue is empty.
 ## Modules
 
 - **spawn** – Handles panic bootstrap and miner demand. Queues miner and
-  hauler tasks so hauler count automatically scales with available miners.
-  Converts room state into HTM tasks consumed by the `spawnManager`.
+  hauler tasks so hauler count automatically scales with available miners. When
+  no creeps remain the module clears the spawn queue and schedules a bootstrap
+  worker so the colony can recover.
   Modules can be added later for building, defense or expansion logic.

--- a/docs/spawnQueue.md
+++ b/docs/spawnQueue.md
@@ -30,3 +30,9 @@ spawnQueue.addToQueue('miner', room.name, body, { role: 'miner' }, spawn.id);
 ```
 
 Requests can include a `ticksToSpawn` delay, allowing future scheduling.
+
+## Clearing a room queue
+
+In panic situations the HiveMind may purge all pending requests for a room. Use
+`spawnQueue.clearRoom(roomName)` to remove every queued entry belonging to that
+room.

--- a/manager.dna.js
+++ b/manager.dna.js
@@ -32,15 +32,17 @@ function getBodyParts(role, room, panic = false) {
 
 function buildMiner(energy, panic) {
   const body = [];
-  let workParts = panic ? 1 : Math.min(5, Math.floor(energy / BODYPART_COST[WORK]));
+  // Always allocate exactly one MOVE to keep miners cheap and stationary
+  const moveCost = BODYPART_COST[MOVE];
+  let availableEnergy = energy - moveCost;
+  if (availableEnergy < 0) availableEnergy = 0;
+  let workParts = panic
+    ? 1
+    : Math.min(5, Math.floor(availableEnergy / BODYPART_COST[WORK]));
   if (workParts < 1) workParts = 1;
-  // Reserve energy for move parts
-  const moveParts = Math.max(1, Math.ceil(workParts / 2));
-  while (workParts > 0 && energy < workParts * BODYPART_COST[WORK] + moveParts * BODYPART_COST[MOVE]) {
-    workParts--;
-  }
+
   for (let i = 0; i < workParts; i++) body.push(WORK);
-  for (let i = 0; i < moveParts; i++) body.push(MOVE);
+  body.push(MOVE);
   return body;
 }
 

--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -31,20 +31,24 @@ const spawnModule = {
 
     // Panic: no creeps present
     const myCreeps = _.filter(Game.creeps, (c) => c.my && c.room.name === roomName);
-    if (
-      myCreeps.length === 0 &&
-      !taskExists(roomName, 'spawnBootstrap', 'spawnManager')
-    ) {
-      htm.addColonyTask(
-        roomName,
-        'spawnBootstrap',
-        { role: 'allPurpose', panic: true },
-        0,
-        20,
-        1,
-        'spawnManager',
-      );
-      logger.log('hivemind.spawn', `Queued bootstrap spawn for ${roomName}`, 2);
+    if (myCreeps.length === 0) {
+      // Emergency: purge existing queue and force a bootstrap creep
+      const removed = spawnQueue.clearRoom(roomName);
+      if (!taskExists(roomName, 'spawnBootstrap', 'spawnManager')) {
+        htm.addColonyTask(
+          roomName,
+          'spawnBootstrap',
+          { role: 'allPurpose', panic: true },
+          0,
+          20,
+          1,
+          'spawnManager',
+        );
+        logger.log('hivemind.spawn', `Queued bootstrap spawn for ${roomName}`, 2);
+      }
+      if (removed > 0) {
+        logger.log('hivemind.spawn', `Cleared ${removed} queued spawns due to panic in ${roomName}` , 3);
+      }
     }
 
     // Determine miner demand based on mining positions and energy

--- a/manager.spawnQueue.js
+++ b/manager.spawnQueue.js
@@ -96,6 +96,27 @@ const spawnQueue = {
   },
 
   /**
+   * Remove all queued spawns for a specific room.
+   * Used in panic situations when the colony needs to bootstrap.
+   *
+   * @param {string} roomName - Room to purge from the queue.
+   * @returns {number} Amount of removed requests.
+   */
+  clearRoom(roomName) {
+    const before = this.queue.length;
+    this.queue = this.queue.filter((req) => req.room !== roomName);
+    const removed = before - this.queue.length;
+    if (removed > 0) {
+      logger.log(
+        "spawnQueue",
+        `Cleared ${removed} queued spawn(s) for room ${roomName}`,
+        2,
+      );
+    }
+    return removed;
+  },
+
+  /**
    * Sorts the queue based on `ticksToSpawn` so earlier requests run first.
    * Future implementations may modify `ticksToSpawn` to reprioritize.
    *

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "chai": "^4.3.7",
+        "lodash": "^4.17.21",
         "mocha": "^10.2.0"
       }
     },
@@ -607,6 +608,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "chai": "^4.3.7",
+    "lodash": "^4.17.21",
     "mocha": "^10.2.0"
   }
 }

--- a/test/dna.test.js
+++ b/test/dna.test.js
@@ -1,0 +1,22 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+global.WORK = 'work';
+global.MOVE = 'move';
+global.BODYPART_COST = { work: 100, move: 50 };
+
+const dna = require('../manager.dna');
+
+describe('dna.getBodyParts', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    Game.rooms['W1N1'] = { energyCapacityAvailable: 300 };
+  });
+
+  it('builds miner with one move part', function() {
+    const parts = dna.getBodyParts('miner', Game.rooms['W1N1']);
+    const moveCount = parts.filter(p => p === MOVE).length;
+    expect(moveCount).to.equal(1);
+  });
+});

--- a/test/spawnQueue.test.js
+++ b/test/spawnQueue.test.js
@@ -1,0 +1,27 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+global._ = require('lodash');
+global.WORK = 'work';
+global.MOVE = 'move';
+global.CARRY = 'carry';
+global.BODYPART_COST = { work: 100, move: 50, carry: 50 };
+
+const spawnQueue = require('../manager.spawnQueue');
+
+describe('spawnQueue.clearRoom', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawnQueue.queue = [];
+  });
+
+  it('removes queued spawns for specific room', function() {
+    spawnQueue.addToQueue('miner', 'W1N1', [WORK, MOVE], { role: 'miner' }, 's1');
+    spawnQueue.addToQueue('hauler', 'W2N2', [CARRY, MOVE], { role: 'hauler' }, 's1');
+    const removed = spawnQueue.clearRoom('W1N1');
+    expect(removed).to.equal(1);
+    expect(spawnQueue.queue.length).to.equal(1);
+    expect(spawnQueue.queue[0].room).to.equal('W2N2');
+  });
+});


### PR DESCRIPTION
## Summary
- keep miners cheap by limiting them to one MOVE part
- allow purge of a room's spawn queue with `clearRoom`
- panic in hivemind clears spawn queue and queues a bootstrap creep
- document clearing room queue and panic behaviour
- add unit tests for DNA miner build and spawn queue purge
- add lodash dev dependency for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844662ec80483279fde7b769cfc4110