### PR TITLE
Improve spawn direction and allPurpose initialization

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,6 +58,7 @@
 - [x] Processes HTM spawn tasks with cooldown estimates
 - [ ] Multi-room spawn and remote queue support
 - [x] Panic mode: minimum creep fallback during total loss – *Prio 5*
+- [x] Direction-aware spawning to keep spawn exits clear
 - [ ] Visual/debug marker for pending spawn queue – *Prio 2*
 
 ### ✅ Building Manager (Prio 3)

--- a/role.allPurpose.js
+++ b/role.allPurpose.js
@@ -3,6 +3,23 @@ const logger = require("./logger");
 
 const roleAllPurpose = {
   run: function (creep) {
+    // Ensure creep knows its energy source
+    if (!creep.memory.source) {
+      const source = creep.pos.findClosestByRange(FIND_SOURCES);
+      if (source) {
+        creep.memory.source = source.id;
+        creep.memory.sourcePosition = {
+          x: source.pos.x,
+          y: source.pos.y,
+          roomName: source.pos.roomName,
+        };
+      }
+    }
+
+    if (creep.memory.working === undefined) {
+      creep.memory.working = false;
+    }
+
     if (!creep.memory.desiredPosition) {
       creep.memory.desiredPosition = {};
     }


### PR DESCRIPTION
## Summary
- pick a nearby source when allPurpose creeps spawn
- spawn creeps with directions toward the chosen source
- pre-assign mining spots for allPurpose workers
- update spawn manager bootstrap handling
- document spawn direction capability in roadmap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844694fd33c83279fae96f222a059b7