### PR TITLE
Fix mining position memory bug

### DIFF
--- a/manager.memory.js
+++ b/manager.memory.js
@@ -134,7 +134,8 @@ const memoryManager = {
       const position = positions[key];
       if (position && !position.reserved) {
         position.reserved = true;
-        creepMemory.miningPosition = position;
+        // Ensure roomName is available for later release and Position usage
+        creepMemory.miningPosition = { ...position, roomName: room.name };
         return true;
       }
     }

--- a/manager.room.js
+++ b/manager.room.js
@@ -43,21 +43,21 @@ const roomManager = {
       const bestPositions = miningSpots.slice(0, 3);
 
       // Structure the memory as an object
-      Memory.rooms[room.name].miningPositions[source.id] = {
-        x: sourcePos.x,
-        y: sourcePos.y,
-        positions: {
-          best1: bestPositions[0]
-            ? { ...bestPositions[0], reserved: false }
-            : null,
-          best2: bestPositions[1]
-            ? { ...bestPositions[1], reserved: false }
-            : null,
-          best3: bestPositions[2]
-            ? { ...bestPositions[2], reserved: false }
-            : null,
-        },
-      };
+        Memory.rooms[room.name].miningPositions[source.id] = {
+          x: sourcePos.x,
+          y: sourcePos.y,
+          positions: {
+            best1: bestPositions[0]
+              ? { ...bestPositions[0], roomName: room.name, reserved: false }
+              : null,
+            best2: bestPositions[1]
+              ? { ...bestPositions[1], roomName: room.name, reserved: false }
+              : null,
+            best3: bestPositions[2]
+              ? { ...bestPositions[2], roomName: room.name, reserved: false }
+              : null,
+          },
+        };
     });
 
     // Additional room-specific data can be gathered here

--- a/test/memoryManager.test.js
+++ b/test/memoryManager.test.js
@@ -1,0 +1,59 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const memoryManager = require('../manager.memory');
+
+// Minimal creep mock used for releaseMiningPosition
+function createCreep(name) {
+  return { name, memory: {} };
+}
+
+describe('memoryManager.assignMiningPosition', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+
+    Game.rooms['W1N1'] = { name: 'W1N1' };
+    Memory.rooms = {
+      W1N1: {
+        miningPositions: {
+          source1: {
+            positions: {
+              best1: { x: 10, y: 20, roomName: 'W1N1', reserved: false },
+            },
+          },
+        },
+      },
+    };
+  });
+
+  it('stores roomName when assigning mining position', function() {
+    const creepMemory = { source: 'source1' };
+    const room = Game.rooms['W1N1'];
+    const assigned = memoryManager.assignMiningPosition(creepMemory, room);
+    expect(assigned).to.be.true;
+    expect(creepMemory.miningPosition).to.deep.equal({
+      x: 10,
+      y: 20,
+      roomName: 'W1N1',
+      reserved: true,
+    });
+  });
+
+  it('releases mining position correctly', function() {
+    const creep = createCreep('miner1');
+    creep.memory.source = 'source1';
+    const room = Game.rooms['W1N1'];
+    memoryManager.assignMiningPosition(creep.memory, room);
+    expect(
+      Memory.rooms.W1N1.miningPositions.source1.positions.best1.reserved
+    ).to.be.true;
+
+    memoryManager.releaseMiningPosition(creep);
+    expect(
+      Memory.rooms.W1N1.miningPositions.source1.positions.best1.reserved
+    ).to.be.false;
+    expect(creep.memory.miningPosition).to.be.undefined;
+  });
+});
+


### PR DESCRIPTION
## Summary
- include `roomName` when saving mining positions to creep memory
- add `roomName` to room mining position data
- test assigning and releasing mining positions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448873645c8327ab144df82daee088