### PR TITLE
Enforce roomName validation on spawn requests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,6 +58,7 @@
 - [x] Processes HTM spawn tasks with cooldown estimates
 - [ ] Multi-room spawn and remote queue support
 - [x] Panic mode: minimum creep fallback during total loss – *Prio 5*
+- [x] Spawn request validation for positional roomName
 - [x] Direction-aware spawning to keep spawn exits clear
 - [ ] Visual/debug marker for pending spawn queue – *Prio 2*
 

--- a/docs/spawnQueue.md
+++ b/docs/spawnQueue.md
@@ -31,6 +31,13 @@ spawnQueue.addToQueue('miner', room.name, body, { role: 'miner' }, spawn.id);
 
 Requests can include a `ticksToSpawn` delay, allowing future scheduling.
 
+### Positional memory requirements
+
+If a request includes `memory.miningPosition` or `memory.sourcePosition`, the
+object **must** contain a `roomName` field. Requests missing the room name are
+rejected by `spawnQueue.addToQueue` to avoid undefined behavior during spawn
+processing.
+
 ## Clearing a room queue
 
 In panic situations the HiveMind may purge all pending requests for a room. Use

--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -310,7 +310,12 @@ const spawnManager = {
           3,
         );
         let spawnPos;
-        if (memory.miningPosition && memory.miningPosition.x !== undefined) {
+        if (
+          memory.miningPosition &&
+          memory.miningPosition.x !== undefined &&
+          memory.miningPosition.roomName
+        ) {
+          // Normal case when assignMiningPosition stored the room name
           spawnPos = new RoomPosition(
             memory.miningPosition.x,
             memory.miningPosition.y,
@@ -318,12 +323,36 @@ const spawnManager = {
           );
         } else if (
           memory.sourcePosition &&
-          memory.sourcePosition.x !== undefined
+          memory.sourcePosition.x !== undefined &&
+          memory.sourcePosition.roomName
         ) {
           spawnPos = new RoomPosition(
             memory.sourcePosition.x,
             memory.sourcePosition.y,
             memory.sourcePosition.roomName,
+          );
+        } else if (
+          memory.miningPosition &&
+          memory.miningPosition.x !== undefined &&
+          !memory.miningPosition.roomName
+        ) {
+          // Backwards compatibility for legacy memory lacking roomName
+          memory.miningPosition.roomName = spawn.room.name;
+          spawnPos = new RoomPosition(
+            memory.miningPosition.x,
+            memory.miningPosition.y,
+            spawn.room.name,
+          );
+        } else if (
+          memory.sourcePosition &&
+          memory.sourcePosition.x !== undefined &&
+          !memory.sourcePosition.roomName
+        ) {
+          memory.sourcePosition.roomName = spawn.room.name;
+          spawnPos = new RoomPosition(
+            memory.sourcePosition.x,
+            memory.sourcePosition.y,
+            spawn.room.name,
           );
         }
 

--- a/manager.spawnQueue.js
+++ b/manager.spawnQueue.js
@@ -34,6 +34,35 @@ const spawnQueue = {
     // Combine current tick with an incrementing counter to avoid collisions
     const requestId = `${Game.time}-${Memory.nextSpawnRequestId++}`;
     const energyRequired = _.sum(bodyParts, (part) => BODYPART_COST[part]);
+
+    // Validate positional data includes roomName to avoid undefined errors later
+    if (
+      memory &&
+      memory.miningPosition &&
+      memory.miningPosition.x !== undefined &&
+      !memory.miningPosition.roomName
+    ) {
+      logger.log(
+        "spawnQueue",
+        `Rejected spawn request ${requestId}: miningPosition missing roomName`,
+        4,
+      );
+      return;
+    }
+    if (
+      memory &&
+      memory.sourcePosition &&
+      memory.sourcePosition.x !== undefined &&
+      !memory.sourcePosition.roomName
+    ) {
+      logger.log(
+        "spawnQueue",
+        `Rejected spawn request ${requestId}: sourcePosition missing roomName`,
+        4,
+      );
+      return;
+    }
+
     this.queue.push({
       requestId,
       category,

--- a/test/spawnQueue.test.js
+++ b/test/spawnQueue.test.js
@@ -25,3 +25,22 @@ describe('spawnQueue.clearRoom', function() {
     expect(spawnQueue.queue[0].room).to.equal('W2N2');
   });
 });
+
+describe('spawnQueue.addToQueue validation', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawnQueue.queue = [];
+  });
+
+  it('rejects requests missing roomName in miningPosition', function() {
+    spawnQueue.addToQueue(
+      'miner',
+      'W1N1',
+      [WORK],
+      { role: 'miner', miningPosition: { x: 1, y: 1 } },
+      's1',
+    );
+    expect(spawnQueue.queue.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce roomName on mining/source positions when adding to spawnQueue
- document the new requirement in `spawnQueue.md`
- mark roadmap item for spawn request validation
- test that missing roomName leads to rejection

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684489d8c97083278f8ff1769fbab582