### PR TITLE
Fix RoomPosition roomName bug and note ES5 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## Overview
 
+This project targets the Screeps runtime which implements **ECMAScript 5.1**. Modern
+ES6+ features such as arrow functions or object spread are not available in-game.
+All code should remain compatible with ES5.1.
+
 Tyranid Screeps mimics a hierarchical swarm. Each module acts like a different
 organism in the hive:
 
@@ -70,4 +74,5 @@ Next step: focus on the hierarchical task system so the scheduler can trigger co
 - [Console Stats](./docs/console.md)
 - [Spawn Queue](./docs/spawnQueue.md)
 - [HiveTravel](./docs/hiveTravel.md)
+- [Runtime Environment](./docs/runtime.md)
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,7 @@
+# Runtime Environment
+
+Screeps executes your code using the ECMA Script 5.1 standard. The engine does not
+support modern ES6+ features, so constructs like arrow functions, classes, or
+object spread should be avoided.
+
+Stick to ES5.1 syntax to ensure scripts execute correctly inside the game.

--- a/manager.memory.js
+++ b/manager.memory.js
@@ -79,14 +79,17 @@ const memoryManager = {
 
     if (!Memory.hive.clusters[clusterId]) {
       Memory.hive.clusters[clusterId] = {
-        ...DEFAULT_CLUSTER_MEMORY,
         colonies: {},
+        meta: {},
       };
     }
 
     if (!Memory.hive.clusters[clusterId].colonies[colonyId]) {
       Memory.hive.clusters[clusterId].colonies[colonyId] = {
-        ...DEFAULT_COLONY_MEMORY,
+        creeps: {},
+        structures: {},
+        tasks: {},
+        meta: {},
       };
     }
   },
@@ -135,7 +138,12 @@ const memoryManager = {
       if (position && !position.reserved) {
         position.reserved = true;
         // Ensure roomName is available for later release and Position usage
-        creepMemory.miningPosition = { ...position, roomName: room.name };
+        creepMemory.miningPosition = {
+          x: position.x,
+          y: position.y,
+          roomName: room.name,
+          reserved: position.reserved,
+        };
         return true;
       }
     }

--- a/manager.room.js
+++ b/manager.room.js
@@ -42,22 +42,37 @@ const roomManager = {
       // Limit to a maximum of 3 positions
       const bestPositions = miningSpots.slice(0, 3);
 
-      // Structure the memory as an object
-        Memory.rooms[room.name].miningPositions[source.id] = {
-          x: sourcePos.x,
-          y: sourcePos.y,
-          positions: {
-            best1: bestPositions[0]
-              ? { ...bestPositions[0], roomName: room.name, reserved: false }
-              : null,
-            best2: bestPositions[1]
-              ? { ...bestPositions[1], roomName: room.name, reserved: false }
-              : null,
-            best3: bestPositions[2]
-              ? { ...bestPositions[2], roomName: room.name, reserved: false }
-              : null,
-          },
-        };
+      // Structure the memory as an object without ES6 spread
+      Memory.rooms[room.name].miningPositions[source.id] = {
+        x: sourcePos.x,
+        y: sourcePos.y,
+        positions: {
+          best1: bestPositions[0]
+            ? {
+                x: bestPositions[0].x,
+                y: bestPositions[0].y,
+                roomName: room.name,
+                reserved: false,
+              }
+            : null,
+          best2: bestPositions[1]
+            ? {
+                x: bestPositions[1].x,
+                y: bestPositions[1].y,
+                roomName: room.name,
+                reserved: false,
+              }
+            : null,
+          best3: bestPositions[2]
+            ? {
+                x: bestPositions[2].x,
+                y: bestPositions[2].y,
+                roomName: room.name,
+                reserved: false,
+              }
+            : null,
+        },
+      };
     });
 
     // Additional room-specific data can be gathered here

--- a/role.allPurpose.js
+++ b/role.allPurpose.js
@@ -58,7 +58,10 @@ const roleAllPurpose = {
     }
 
     if (creep.memory.desiredPosition && creep.memory.desiredPosition.x !== undefined) {
-      const target = new RoomPosition(creep.memory.desiredPosition.x, creep.memory.desiredPosition.y, creep.memory.desiredPosition.roomName);
+      // Fallback to the creep's current room if roomName is missing
+      var dp = creep.memory.desiredPosition;
+      var targetRoom = dp.roomName || creep.room.name;
+      var target = new RoomPosition(dp.x, dp.y, targetRoom);
       if (!creep.pos.isEqualTo(target)) {
         creep.travelTo(target);
       }
@@ -123,26 +126,15 @@ const roleAllPurpose = {
       }
     }
 
-    const miningPos = creep.memory.miningPosition;
+    var miningPos = creep.memory.miningPosition;
     if (!creep.pos.isEqualTo(miningPos.x, miningPos.y)) {
-      creep.memory.desiredPosition = new RoomPosition(
-        miningPos.x,
-        miningPos.y,
-        miningPos.roomName,
-      );
+      var roomName = miningPos.roomName || creep.room.name;
+      creep.memory.desiredPosition = new RoomPosition(miningPos.x, miningPos.y, roomName);
     } else {
-      const sourcePos = creep.memory.sourcePosition;
-      if (
-        sourcePos &&
-        sourcePos.x !== undefined &&
-        sourcePos.y !== undefined &&
-        sourcePos.roomName
-      ) {
-        const source = new RoomPosition(
-          sourcePos.x,
-          sourcePos.y,
-          sourcePos.roomName,
-        ).findClosestByRange(FIND_SOURCES);
+      var sourcePos = creep.memory.sourcePosition;
+      if (sourcePos && sourcePos.x !== undefined && sourcePos.y !== undefined && sourcePos.roomName) {
+        var sRoom = sourcePos.roomName || creep.room.name;
+        var source = new RoomPosition(sourcePos.x, sourcePos.y, sRoom).findClosestByRange(FIND_SOURCES);
         const harvestResult = creep.harvest(source);
         if (harvestResult === OK) {
           logger.log(


### PR DESCRIPTION
## Summary
- prevent undefined `roomName` when creating `RoomPosition` objects
- store mining position data without using object spread
- build mining memory with ES5 object syntax
- document that Screeps runs on ES5.1
- add new runtime environment doc

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68449025d570832791c4d63baa493e12