### PR TITLE
Improve energy logistics and hauler behavior

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,6 +48,7 @@
 - [x] Basic skeleton with scheduler hook
 - [x] Basic HiveMind decision module queues tasks
 - [x] Task claiming with cooldown and amount tracking
+- [x] Creep energy request tasks claimed by haulers
 - [x] Dynamic miner evaluation based on room energy
 - [x] Modular HiveMind with spawn and subconscious modules
 
@@ -64,6 +65,7 @@
 
 ### ✅ Building Manager (Prio 3)
 - [x] Queues container and extension construction
+- [x] Places containers near controller and spawn for early storage
 - [x] Recalculates buildable areas on controller level change
 - [x] Prioritizes build sites via weighted queue
 

--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -128,6 +128,20 @@ const spawnModule = {
       }
     }
 
+    const liveUpgraders = _.filter(Game.creeps, c => c.memory.role === 'upgrader' && c.room.name === roomName).length;
+    const queuedUpgraders = spawnQueue.queue.filter(req => req.memory.role === 'upgrader' && req.room === roomName).length;
+    const desiredUpgraders = Math.max(1, Math.ceil(room.controller.level / 2));
+    const upgradersNeeded = Math.max(0, desiredUpgraders - liveUpgraders - queuedUpgraders);
+    const upgraderTask = container && container.tasks ? container.tasks.find(t => t.name === 'spawnUpgrader' && t.manager === 'spawnManager') : null;
+    if (upgradersNeeded > 0) {
+      if (upgraderTask) {
+        upgraderTask.amount = upgradersNeeded;
+      } else {
+        htm.addColonyTask(roomName, 'spawnUpgrader', { role: 'upgrader' }, 1, 20, upgradersNeeded, 'spawnManager');
+        logger.log('hivemind.spawn', `Queued ${upgradersNeeded} upgrader spawn(s) for ${roomName}`, 2);
+      }
+    }
+
     // Encourage upgrades when energy is abundant
     if (
       room.energyAvailable > room.energyCapacityAvailable * 0.8 &&

--- a/manager.room.js
+++ b/manager.room.js
@@ -12,7 +12,9 @@ const roomManager = {
     }
 
     const sources = room.find(FIND_SOURCES);
-    Memory.rooms[room.name].miningPositions = {};
+    if (!Memory.rooms[room.name].miningPositions) {
+      Memory.rooms[room.name].miningPositions = {};
+    }
 
     sources.forEach((source) => {
       const spawn = room.find(FIND_MY_SPAWNS)[0]; // Assuming there's at least one spawn
@@ -42,13 +44,14 @@ const roomManager = {
       // Limit to a maximum of 3 positions
       const bestPositions = miningSpots.slice(0, 3);
 
-      // Structure the memory as an object without ES6 spread
-      Memory.rooms[room.name].miningPositions[source.id] = {
-        x: sourcePos.x,
-        y: sourcePos.y,
-        positions: {
-          best1: bestPositions[0]
-            ? {
+      // Only initialize if not already present to preserve reservation state
+      if (!Memory.rooms[room.name].miningPositions[source.id]) {
+        Memory.rooms[room.name].miningPositions[source.id] = {
+          x: sourcePos.x,
+          y: sourcePos.y,
+          positions: {
+            best1: bestPositions[0]
+              ? {
                 x: bestPositions[0].x,
                 y: bestPositions[0].y,
                 roomName: room.name,
@@ -63,16 +66,17 @@ const roomManager = {
                 reserved: false,
               }
             : null,
-          best3: bestPositions[2]
-            ? {
+            best3: bestPositions[2]
+              ? {
                 x: bestPositions[2].x,
                 y: bestPositions[2].y,
                 roomName: room.name,
                 reserved: false,
               }
-            : null,
-        },
-      };
+              : null,
+          },
+        };
+      }
     });
 
     // Additional room-specific data can be gathered here

--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -233,6 +233,27 @@ const spawnManager = {
   },
 
   /**
+   * Spawns an upgrader with the appropriate body parts based on energy.
+   * @param {StructureSpawn} spawn - Spawn structure to use.
+   * @param {Room} room - Room context for calculations.
+   */
+  spawnUpgrader(spawn, room) {
+    const bodyParts = dna.getBodyParts("upgrader", room);
+    spawnQueue.addToQueue(
+      "upgrader",
+      room.name,
+      bodyParts,
+      { role: "upgrader" },
+      spawn.id,
+    );
+    logger.log(
+      "spawnManager",
+      `Added upgrader creep to spawn queue in room ${room.name}`,
+      2,
+    );
+  },
+
+  /**
    * Spawn an allPurpose worker and pre-assign a mining position if possible.
    * @param {StructureSpawn} spawn - The spawn to create the request for.
    * @param {Room} room - The room context.
@@ -434,6 +455,17 @@ const spawnManager = {
             'spawnManager',
             DEFAULT_CLAIM_COOLDOWN,
             dna.getBodyParts('hauler', room).length * CREEP_SPAWN_TIME,
+          );
+          break;
+        case 'spawnUpgrader':
+          this.spawnUpgrader(spawn, room);
+          htm.claimTask(
+            htm.LEVELS.COLONY,
+            room.name,
+            task.name,
+            'spawnManager',
+            DEFAULT_CLAIM_COOLDOWN,
+            dna.getBodyParts('upgrader', room).length * CREEP_SPAWN_TIME,
           );
           break;
         case 'spawnBootstrap':

--- a/role.builder.js
+++ b/role.builder.js
@@ -1,3 +1,23 @@
+const htm = require('./manager.htm');
+
+function requestEnergy(creep) {
+  if (htm.hasTask(htm.LEVELS.CREEP, creep.name, 'deliverEnergy', 'hauler')) return;
+  const spawn = creep.room.find(FIND_MY_SPAWNS)[0];
+  const distance = spawn ? spawn.pos.getRangeTo(creep) : 10;
+  htm.addCreepTask(
+    creep.name,
+    'deliverEnergy',
+    {
+      pos: { x: creep.pos.x, y: creep.pos.y, roomName: creep.room.name },
+      ticksNeeded: distance * 2,
+    },
+    1,
+    50,
+    1,
+    'hauler',
+  );
+}
+
 const roleBuilder = {
   run: function (creep) {
     if (creep.memory.working && creep.store[RESOURCE_ENERGY] === 0) {
@@ -41,41 +61,8 @@ const roleBuilder = {
         }
       }
     } else {
-      const droppedEnergy = creep.pos.findClosestByPath(
-        FIND_DROPPED_RESOURCES,
-        {
-          filter: (resource) => resource.resourceType === RESOURCE_ENERGY,
-        },
-      );
-      const container = creep.pos.findClosestByPath(FIND_STRUCTURES, {
-        filter: (structure) =>
-          structure.structureType === STRUCTURE_CONTAINER &&
-          structure.store[RESOURCE_ENERGY] > 0,
-      });
-
-      if (droppedEnergy) {
-        const highestEnergy = creep.room
-          .find(FIND_DROPPED_RESOURCES, {
-            filter: (resource) => resource.resourceType === RESOURCE_ENERGY,
-          })
-          .sort((a, b) => b.amount - a.amount)[0];
-
-        if (creep.pickup(highestEnergy) === ERR_NOT_IN_RANGE) {
-          creep.travelTo(highestEnergy, {
-            visualizePathStyle: { stroke: "#ffaa00" },
-          });
-        }
-      } else if (container) {
-        if (creep.withdraw(container, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-          creep.travelTo(container, {
-            visualizePathStyle: { stroke: "#ffaa00" },
-          });
-        }
-      } else {
-        const source = creep.pos.findClosestByPath(FIND_SOURCES_ACTIVE);
-        if (source && creep.harvest(source) === ERR_NOT_IN_RANGE) {
-          creep.travelTo(source, { visualizePathStyle: { stroke: "#ffaa00" } });
-        }
+      if (creep.store[RESOURCE_ENERGY] === 0) {
+        requestEnergy(creep);
       }
     }
   },

--- a/role.hauler.js
+++ b/role.hauler.js
@@ -1,7 +1,81 @@
 // role.hauler.js
 
+const htm = require('manager.htm');
+const logger = require('./logger');
+
 module.exports = {
   run: function (creep) {
+    const spawn = creep.pos.findClosestByRange(FIND_MY_SPAWNS);
+    if (spawn && creep.pos.isNearTo(spawn)) {
+      const nearbyDemand = spawn.pos
+        .findInRange(FIND_STRUCTURES, 1, {
+          filter: (s) =>
+            (s.structureType === STRUCTURE_EXTENSION ||
+              s.structureType === STRUCTURE_SPAWN) &&
+            s.store.getFreeCapacity(RESOURCE_ENERGY) > 0,
+        })
+        .length;
+      if (nearbyDemand === 0) {
+        creep.travelTo(spawn, { range: 2 });
+        return;
+      }
+    }
+    // Active delivery task takes priority
+    if (creep.memory.task && creep.memory.task.name === 'deliverEnergy') {
+      const target = Game.creeps[creep.memory.task.target];
+      if (!target) {
+        htm.addCreepTask(
+          creep.memory.task.target,
+          'deliverEnergy',
+          { pos: creep.memory.task.pos },
+          1,
+          20,
+          1,
+          'hauler',
+        );
+        delete creep.memory.task;
+      } else if (creep.store[RESOURCE_ENERGY] > 0) {
+        if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+          creep.travelTo(target, { visualizePathStyle: { stroke: '#ffffff' } });
+        } else if (creep.store[RESOURCE_ENERGY] === 0) {
+          delete creep.memory.task;
+        }
+        return;
+      } else {
+        const container = creep.pos.findClosestByPath(FIND_STRUCTURES, {
+          filter: (structure) =>
+            structure.structureType === STRUCTURE_CONTAINER &&
+            structure.store[RESOURCE_ENERGY] > 0,
+        });
+        if (container) {
+          if (creep.withdraw(container, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+            creep.travelTo(container, { visualizePathStyle: { stroke: '#ffaa00' } });
+          }
+        }
+        return;
+      }
+    }
+
+    // Look for delivery tasks
+    const creepTasks = Memory.htm && Memory.htm.creeps ? Memory.htm.creeps : {};
+    for (const name in creepTasks) {
+      const container = creepTasks[name];
+      if (!container.tasks) continue;
+      const task = container.tasks.find(
+        (t) => t.name === 'deliverEnergy' && Game.time >= t.claimedUntil,
+      );
+      if (!task) continue;
+      const estimate = task.data.ticksNeeded || 0;
+      if (creep.ticksToLive && creep.ticksToLive <= estimate) continue;
+      htm.claimTask(htm.LEVELS.CREEP, name, 'deliverEnergy', 'hauler', htm.DEFAULT_CLAIM_COOLDOWN, estimate);
+      creep.memory.task = {
+        name: 'deliverEnergy',
+        target: name,
+        pos: task.data.pos,
+      };
+      break;
+    }
+
     // Check if creep is carrying energy and is not already transferring energy
     if (creep.store[RESOURCE_ENERGY] > 0) {
       // Prioritize filling extensions first, then the spawn
@@ -62,6 +136,19 @@ module.exports = {
         }
         return;
       }
+    }
+  },
+  onDeath: function (creep) {
+    if (creep.memory.task && creep.memory.task.name === 'deliverEnergy') {
+      htm.addCreepTask(
+        creep.memory.task.target,
+        'deliverEnergy',
+        { pos: creep.memory.task.pos },
+        1,
+        20,
+        1,
+        'hauler',
+      );
     }
   },
 };

--- a/role.upgrader.js
+++ b/role.upgrader.js
@@ -1,46 +1,35 @@
 const statsConsole = require("console.console");
+const htm = require("./manager.htm");
+
+function requestEnergy(creep) {
+  if (htm.hasTask(htm.LEVELS.CREEP, creep.name, 'deliverEnergy', 'hauler')) return;
+  const spawn = creep.room.find(FIND_MY_SPAWNS)[0];
+  const distance = spawn ? spawn.pos.getRangeTo(creep) : 10;
+  htm.addCreepTask(
+    creep.name,
+    'deliverEnergy',
+    {
+      pos: { x: creep.pos.x, y: creep.pos.y, roomName: creep.room.name },
+      ticksNeeded: distance * 2,
+    },
+    1,
+    50,
+    1,
+    'hauler',
+  );
+}
 
 const roleUpgrader = {
   run: function (creep) {
     if (creep.store[RESOURCE_ENERGY] === 0) {
-      const droppedEnergy = creep.pos.findClosestByPath(
-        FIND_DROPPED_RESOURCES,
-        {
-          filter: (resource) => resource.resourceType === RESOURCE_ENERGY,
-        },
-      );
-      const container = creep.pos.findClosestByPath(FIND_STRUCTURES, {
-        filter: (structure) =>
-          structure.structureType === STRUCTURE_CONTAINER &&
-          structure.store[RESOURCE_ENERGY] > 0,
-      });
+      requestEnergy(creep);
+      return;
+    }
 
-      if (droppedEnergy) {
-        if (creep.pickup(droppedEnergy) === ERR_NOT_IN_RANGE) {
-          creep.travelTo(droppedEnergy, {
-            visualizePathStyle: { stroke: "#ffaa00" },
-          });
-        }
-      } else if (container) {
-        if (creep.withdraw(container, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-          creep.travelTo(container, {
-            visualizePathStyle: { stroke: "#ffaa00" },
-          });
-        }
-      } else {
-        const sources = creep.room.find(FIND_SOURCES);
-        if (creep.harvest(sources[0]) === ERR_NOT_IN_RANGE) {
-          creep.travelTo(sources[0], {
-            visualizePathStyle: { stroke: "#ffaa00" },
-          });
-        }
-      }
-    } else {
-      if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
-        creep.travelTo(creep.room.controller, {
-          visualizePathStyle: { stroke: "#ffffff" },
-        });
-      }
+    if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
+      creep.travelTo(creep.room.controller, {
+        visualizePathStyle: { stroke: "#ffffff" },
+      });
     }
   },
 };

--- a/test/energyRequest.test.js
+++ b/test/energyRequest.test.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const htm = require('../manager.htm');
+const roleUpgrader = require('../role.upgrader');
+
+global.FIND_MY_SPAWNS = 1;
+global.RESOURCE_ENERGY = 'energy';
+global.OK = 0;
+
+function createCreep(name) {
+  return {
+    name,
+    room: Game.rooms['W1N1'],
+    store: { [RESOURCE_ENERGY]: 0, getFreeCapacity: () => 50 },
+    pos: { x: 10, y: 10, roomName: 'W1N1', getRangeTo: () => 5 },
+    travelTo: () => {},
+    upgradeController: () => OK,
+    memory: {},
+  };
+}
+
+describe('energy request tasks', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    Game.rooms['W1N1'] = { name: 'W1N1', find: () => [], controller: {} };
+    htm.init();
+  });
+
+  it('queues deliverEnergy when upgrader is empty', function() {
+    const creep = createCreep('u1');
+    roleUpgrader.run(creep);
+    const tasks = Memory.htm.creeps['u1'].tasks;
+    expect(tasks[0].name).to.equal('deliverEnergy');
+  });
+});

--- a/test/memoryManager.test.js
+++ b/test/memoryManager.test.js
@@ -20,6 +20,7 @@ describe('memoryManager.assignMiningPosition', function() {
           source1: {
             positions: {
               best1: { x: 10, y: 20, roomName: 'W1N1', reserved: false },
+              best2: { x: 11, y: 20, roomName: 'W1N1', reserved: false },
             },
           },
         },
@@ -54,6 +55,21 @@ describe('memoryManager.assignMiningPosition', function() {
       Memory.rooms.W1N1.miningPositions.source1.positions.best1.reserved
     ).to.be.false;
     expect(creep.memory.miningPosition).to.be.undefined;
+  });
+
+  it('assigns unique positions for multiple creeps', function() {
+    const room = Game.rooms['W1N1'];
+    const creep1 = { memory: { source: 'source1' } };
+    const creep2 = { memory: { source: 'source1' } };
+    memoryManager.assignMiningPosition(creep1.memory, room);
+    memoryManager.assignMiningPosition(creep2.memory, room);
+
+    expect(creep1.memory.miningPosition).to.not.deep.equal(creep2.memory.miningPosition);
+    const pos1 = creep1.memory.miningPosition;
+    const pos2 = creep2.memory.miningPosition;
+    expect(Memory.rooms.W1N1.miningPositions.source1.positions.best1.reserved || Memory.rooms.W1N1.miningPositions.source1.positions.best2.reserved).to.be.true;
+    expect(pos1).to.have.property('roomName', 'W1N1');
+    expect(pos2).to.have.property('roomName', 'W1N1');
   });
 });
 


### PR DESCRIPTION
## Summary
- reuse stored mining positions for container placement
- add energy request tasks for builders and upgraders
- allow haulers to claim and complete deliverEnergy tasks
- keep haulers away from spawn unless actively delivering
- new unit test covering energy request workflow

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68449917c1ec83278b529bc2bfd7ec88