### PR TITLE
Refine bootstrap creep behavior

### DIFF
--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -105,6 +105,7 @@ const spawnModule = {
           logger.log('hivemind.spawn', `Updated miner task amount to ${minersNeeded} for ${roomName}`, 2);
         }
       } else {
+        // Priority 1 so the first replacement after a bootstrap is always a miner
         htm.addColonyTask(
           roomName,
           'spawnMiner',
@@ -130,7 +131,8 @@ const spawnModule = {
       if (haulTask) {
         haulTask.amount = haulersNeeded;
       } else {
-        htm.addColonyTask(roomName, "spawnHauler", { role: "hauler" }, 1, 20, haulersNeeded, "spawnManager");
+        // Haulers spawn after miners to keep the initial economy stable
+        htm.addColonyTask(roomName, "spawnHauler", { role: "hauler" }, 2, 20, haulersNeeded, "spawnManager");
         logger.log('hivemind.spawn', `Queued ${haulersNeeded} hauler spawn(s) for ${roomName}`, 2);
       }
     }
@@ -144,7 +146,8 @@ const spawnModule = {
       if (upgraderTask) {
         upgraderTask.amount = upgradersNeeded;
       } else {
-        htm.addColonyTask(roomName, 'spawnUpgrader', { role: 'upgrader' }, 1, 20, upgradersNeeded, 'spawnManager');
+        // Upgraders are lower priority than miners and haulers during bootstrap
+        htm.addColonyTask(roomName, 'spawnUpgrader', { role: 'upgrader' }, 3, 20, upgradersNeeded, 'spawnManager');
         logger.log('hivemind.spawn', `Queued ${upgradersNeeded} upgrader spawn(s) for ${roomName}`, 2);
       }
     }

--- a/role.allPurpose.js
+++ b/role.allPurpose.js
@@ -103,10 +103,12 @@ const roleAllPurpose = {
 
 
   performCollect: function (creep) {
-    // Check for dropped energy first
+    // Check for dropped energy large enough to fill the creep completely
+    const needed = creep.store.getFreeCapacity(RESOURCE_ENERGY);
     const droppedEnergy = creep.pos.findClosestByPath(FIND_DROPPED_RESOURCES, {
       filter: (resource) =>
-        resource.resourceType === RESOURCE_ENERGY && resource.amount >= 50,
+        resource.resourceType === RESOURCE_ENERGY &&
+        resource.amount >= needed,
     });
 
     if (droppedEnergy) {

--- a/test/allPurposeCollect.test.js
+++ b/test/allPurposeCollect.test.js
@@ -1,0 +1,87 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const roleAllPurpose = require('../role.allPurpose');
+
+// Global constants required by the role logic
+global.FIND_DROPPED_RESOURCES = 1;
+global.FIND_SOURCES = 2;
+global.FIND_STRUCTURES = 3;
+global.STRUCTURE_EXTENSION = 'extension';
+global.STRUCTURE_SPAWN = 'spawn';
+global.FIND_MY_SPAWNS = 4;
+global.RESOURCE_ENERGY = 'energy';
+global.OK = 0;
+global.ERR_NOT_IN_RANGE = -9;
+
+// Minimal RoomPosition mock used by the role
+global.RoomPosition = function (x, y, roomName) {
+  this.x = x;
+  this.y = y;
+  this.roomName = roomName;
+  this.isEqualTo = function (x2, y2) {
+    if (typeof x2 === 'object') {
+      return this.x === x2.x && this.y === x2.y && this.roomName === x2.roomName;
+    }
+    return this.x === x2 && this.y === y2;
+  };
+  this.findClosestByRange = () => ({ id: 's1', pos: this });
+};
+
+function createCreep(dropped) {
+  return {
+    name: 'ap1',
+    room: { name: 'W1N1', controller: {}, find: () => [] },
+    store: { [RESOURCE_ENERGY]: 0, getFreeCapacity: () => 50 },
+    pos: {
+      x: 5,
+      y: 5,
+      roomName: 'W1N1',
+      findClosestByRange: () => null,
+      findClosestByPath: (type, opts) => {
+        if (type !== FIND_DROPPED_RESOURCES) return null;
+        if (opts && typeof opts.filter === 'function' && !opts.filter(dropped)) {
+          return null;
+        }
+        return dropped;
+      },
+      isNearTo: () => false,
+      isEqualTo: () => false,
+    },
+    travelTo: () => {},
+    pickup: () => ERR_NOT_IN_RANGE,
+    harvest: () => OK,
+    transfer: () => OK,
+    upgradeController: () => OK,
+    say: () => {},
+    memory: {
+      source: 's1',
+      sourcePosition: { x: 6, y: 6, roomName: 'W1N1' },
+      miningPosition: { x: 1, y: 1, roomName: 'W1N1', reserved: true },
+      working: false,
+      desiredPosition: {},
+    },
+  };
+}
+
+describe('allPurpose energy collection', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory();
+    Game.rooms['W1N1'] = { name: 'W1N1', find: () => [] };
+  });
+
+  it('moves to dropped energy when enough is available', function () {
+    const dropped = { resourceType: RESOURCE_ENERGY, amount: 50, pos: { x: 4, y: 4, roomName: 'W1N1' } };
+    const creep = createCreep(dropped);
+    roleAllPurpose.run(creep);
+    expect(creep.memory.desiredPosition).to.include(dropped.pos);
+  });
+
+  it('uses mining position when dropped energy is insufficient', function () {
+    const dropped = { resourceType: RESOURCE_ENERGY, amount: 10, pos: { x: 4, y: 4, roomName: 'W1N1' } };
+    const creep = createCreep(dropped);
+    roleAllPurpose.run(creep);
+    expect(creep.memory.desiredPosition).to.include({ x: 1, y: 1, roomName: 'W1N1' });
+  });
+});


### PR DESCRIPTION
## Summary
- prioritize miners by delaying haulers and upgraders
- tune allPurpose creep to pick up large dropped energy first
- add tests for allPurpose collection logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a7881220832791da809ccd4a823a