### PR TITLE
Improve hivemind spawn logic

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,6 +62,7 @@
 - [x] Panic mode: minimum creep fallback during total loss – *Prio 5*
 - [x] Spawn request validation for positional roomName
 - [x] Direction-aware spawning to keep spawn exits clear
+- [x] Builder spawn logic driven by HiveMind
 - [ ] Visual/debug marker for pending spawn queue – *Prio 2*
 
 ### ✅ Building Manager (Prio 3)

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -25,8 +25,10 @@ its queue is empty.
 
 ## Modules
 
-- **spawn** – Handles panic bootstrap and miner demand. Queues miner and
-  hauler tasks so hauler count automatically scales with available miners. When
-  no creeps remain the module clears the spawn queue and schedules a bootstrap
-  worker so the colony can recover.
+- **spawn** – Maintains the workforce. Miners are requested based on available
+  mining spots and work parts (typically three per source at RCL1). Haulers are
+  queued once miners exist and scale back as the room develops. A baseline
+  upgrader is always ensured and builders are spawned when construction projects
+  are detected. When no creeps remain the queue is purged and a bootstrap worker
+  is scheduled so the colony can recover.
   Modules can be added later for building, defense or expansion logic.

--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -255,6 +255,27 @@ const spawnManager = {
   },
 
   /**
+   * Spawns a builder with the appropriate body parts based on energy.
+   * @param {StructureSpawn} spawn - Spawn structure to use.
+   * @param {Room} room - Room context for calculations.
+   */
+  spawnBuilder(spawn, room) {
+    const bodyParts = dna.getBodyParts("builder", room);
+    spawnQueue.addToQueue(
+      "builder",
+      room.name,
+      bodyParts,
+      { role: "builder" },
+      spawn.id,
+    );
+    logger.log(
+      "spawnManager",
+      `Added builder creep to spawn queue in room ${room.name}`,
+      2,
+    );
+  },
+
+  /**
    * Spawn an allPurpose worker and pre-assign a mining position if possible.
    * @param {StructureSpawn} spawn - The spawn to create the request for.
    * @param {Room} room - The room context.
@@ -514,6 +535,17 @@ const spawnManager = {
             'spawnManager',
             DEFAULT_CLAIM_COOLDOWN,
             dna.getBodyParts('upgrader', room).length * CREEP_SPAWN_TIME,
+          );
+          break;
+        case 'spawnBuilder':
+          this.spawnBuilder(spawn, room);
+          htm.claimTask(
+            htm.LEVELS.COLONY,
+            room.name,
+            task.name,
+            'spawnManager',
+            DEFAULT_CLAIM_COOLDOWN,
+            dna.getBodyParts('builder', room).length * CREEP_SPAWN_TIME,
           );
           break;
         case 'spawnBootstrap':


### PR DESCRIPTION
## Summary
- support builder spawning via `manager.spawn`
- adjust hauler calculation and add builder logic to HiveMind spawn module
- cap upgrader count and spawn builders when construction exists
- document new HiveMind spawn behaviour
- track builder spawn task on roadmap
- add tests for HiveMind spawn requests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844aa7ea2dc832782efde2f4ad42977