### PR TITLE
Improve early spawn order and creep setup

### DIFF
--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -300,6 +300,11 @@ const spawnManager = {
           y: source.pos.y,
           roomName: source.pos.roomName,
         };
+        creepMemory.desiredPosition = {
+          x: creepMemory.miningPosition.x,
+          y: creepMemory.miningPosition.y,
+          roomName: creepMemory.miningPosition.roomName,
+        };
         spawnQueue.addToQueue(
           "allPurpose",
           room.name,
@@ -320,7 +325,11 @@ const spawnManager = {
         role: "allPurpose",
         source: fallback.id,
         working: false,
-        desiredPosition: {},
+        desiredPosition: {
+          x: fallback.pos.x,
+          y: fallback.pos.y,
+          roomName: fallback.pos.roomName,
+        },
         sourcePosition: {
           x: fallback.pos.x,
           y: fallback.pos.y,


### PR DESCRIPTION
## Summary
- define an initial spawn sequence in the HiveMind spawn module
- ensure hauler demand counts queued miners
- always keep one builder for repairs
- set desiredPosition on spawned allPurpose creeps so they move immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b0ba15a0832794b94b383716e6c0