### PR TITLE
Improve build prioritization and restricted areas

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,6 +157,7 @@
 - [ ] Analyze room structures by RCL
 - [ ] Auto-place extensions, roads, containers, towers
 - [ ] Plan paths from sources to controller/spawns/storage
+- [x] Declare spawn restricted area in memory for movement logic
 
 ### 🐞 Debug Tools
 - [ ] `console.command('scan')` for room diagnostics

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -35,6 +35,10 @@ its queue is empty.
   The HiveMind also orders basic infrastructure:
   - Containers are planned as soon as the room is claimed (RCL1).
   - Extensions begin construction when the controller reaches RCL2.
+  - Source containers are prioritized before extensions, followed by controller
+    and buffer containers.
   - Mining positions are freed when miners approach expiry so replacements
     can claim the same spot. Any leftover reservations are cleared when
     miners or allPurpose creeps die.
+  - Restricted tiles around the spawn are stored in room memory so creeps avoid
+    blocking it.

--- a/manager.building.js
+++ b/manager.building.js
@@ -86,11 +86,16 @@ const buildingManager = {
     this.manageBuildingQueue(room);
 
     if (room.controller.level >= 1) {
-      this.buildContainers(room);
+      this.buildSourceContainers(room);
     }
 
     if (room.controller.level >= 2) {
       this.buildExtensions(room);
+    }
+
+    if (room.controller.level >= 1) {
+      this.buildControllerContainers(room);
+      this.buildBufferContainer(room);
     }
   },
 
@@ -120,7 +125,7 @@ const buildingManager = {
     return weight;
   },
 
-  buildContainers: function (room) {
+  buildSourceContainers: function (room) {
     const sources = room.find(FIND_SOURCES);
     for (const source of sources) {
       const sourceMem =
@@ -146,7 +151,10 @@ const buildingManager = {
         }
       }
     }
+  },
 
+  buildControllerContainers: function (room) {
+    if (!room.controller) return;
     // Controller containers
     if (room.controller) {
       const controllerContainers = room.controller.pos.findInRange(FIND_STRUCTURES, 3, {
@@ -179,23 +187,23 @@ const buildingManager = {
         }
       }
     }
+  },
 
-    // Spawn buffer container
+  buildBufferContainer: function (room) {
     const spawn = room.find(FIND_MY_SPAWNS)[0];
-    if (spawn) {
-      const nearbyContainers = spawn.pos.findInRange(FIND_STRUCTURES, 2, {
-        filter: s => s.structureType === STRUCTURE_CONTAINER,
-      });
-      const nearbySites = spawn.pos.findInRange(FIND_CONSTRUCTION_SITES, 2, {
-        filter: s => s.structureType === STRUCTURE_CONTAINER,
-      });
-      if (nearbyContainers.length + nearbySites.length === 0) {
-        const spots = getOpenSpots(spawn.pos, 2);
-        if (spots.length > 0) {
-          const pos = new RoomPosition(spots[0].x, spots[0].y, room.name);
-          room.createConstructionSite(pos, STRUCTURE_CONTAINER);
-          statsConsole.log(`Queued spawn buffer container at ${pos}`, 6);
-        }
+    if (!spawn) return;
+    const nearbyContainers = spawn.pos.findInRange(FIND_STRUCTURES, 2, {
+      filter: s => s.structureType === STRUCTURE_CONTAINER,
+    });
+    const nearbySites = spawn.pos.findInRange(FIND_CONSTRUCTION_SITES, 2, {
+      filter: s => s.structureType === STRUCTURE_CONTAINER,
+    });
+    if (nearbyContainers.length + nearbySites.length === 0) {
+      const spots = getOpenSpots(spawn.pos, 2);
+      if (spots.length > 0) {
+        const pos = new RoomPosition(spots[0].x, spots[0].y, room.name);
+        room.createConstructionSite(pos, STRUCTURE_CONTAINER);
+        statsConsole.log(`Queued spawn buffer container at ${pos}`, 6);
       }
     }
   },

--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -26,6 +26,21 @@ const spawnModule = {
   run(room) {
     const roomName = room.name;
 
+    const spawnStruct = room.find(FIND_MY_SPAWNS)[0];
+    if (spawnStruct) {
+      const area = [];
+      for (let dx = -1; dx <= 1; dx++) {
+        for (let dy = -1; dy <= 1; dy++) {
+          const x = spawnStruct.pos.x + dx;
+          const y = spawnStruct.pos.y + dy;
+          if (x < 0 || x > 49 || y < 0 || y > 49) continue;
+          area.push({ x, y });
+        }
+      }
+      if (!Memory.rooms[roomName]) Memory.rooms[roomName] = {};
+      Memory.rooms[roomName].restrictedArea = area;
+    }
+
     // Defense task on hostiles
     const hostileCount = room.find(FIND_HOSTILE_CREEPS).length;
     if (hostileCount > 0 && !taskExists(roomName, 'defendRoom')) {

--- a/manager.memory.js
+++ b/manager.memory.js
@@ -53,6 +53,7 @@ const memoryManager = {
       Memory.rooms[room.name] = {
         miningPositions: {},
         reservedPositions: {},
+        restrictedArea: [],
       };
     }
 

--- a/test/builderAssignment.test.js
+++ b/test/builderAssignment.test.js
@@ -1,0 +1,64 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const roleBuilder = require('../role.builder');
+
+global.FIND_CONSTRUCTION_SITES = 1;
+global.FIND_MY_SPAWNS = 2;
+global.STRUCTURE_CONTAINER = 'container';
+global.RESOURCE_ENERGY = 'energy';
+global.OK = 0;
+
+function createSite(id) {
+  return {
+    id,
+    progress: 0,
+    progressTotal: 100,
+    structureType: STRUCTURE_CONTAINER,
+    pos: { x: 1, y: 1, roomName: 'W1N1', lookFor: () => [] },
+  };
+}
+
+function createCreep(name) {
+  return {
+    name,
+    memory: { working: true },
+    room: Game.rooms['W1N1'],
+    store: { [RESOURCE_ENERGY]: 50, getFreeCapacity: () => 0 },
+    pos: {
+      x: 10,
+      y: 10,
+      roomName: 'W1N1',
+      getRangeTo: () => 1,
+      findClosestByRange: () => null,
+      findInRange: () => [],
+    },
+    travelTo: () => {},
+    build: () => OK,
+    upgradeController: () => OK,
+  };
+}
+
+describe('builder assignment', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory();
+    const site = createSite('s1');
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      find: type => (type === FIND_CONSTRUCTION_SITES ? [site] : []),
+      memory: { buildingQueue: [{ id: 's1', priority: 100 }] },
+      controller: {},
+    };
+    Game.getObjectById = () => site;
+    Memory.rooms = { W1N1: { buildingQueue: [{ id: 's1', priority: 100 }], siteAssignments: {} } };
+  });
+
+  it('limits builders per site to four', function () {
+    for (let i = 0; i < 5; i++) {
+      const c = createCreep('b' + i);
+      roleBuilder.run(c);
+    }
+    expect(Memory.rooms.W1N1.siteAssignments['s1']).to.equal(4);
+  });
+});

--- a/utils.movement.js
+++ b/utils.movement.js
@@ -7,6 +7,16 @@ const movementUtils = {
     if (!creep.pos || !creep.pos.findClosestByRange) return;
     const spawn = creep.pos.findClosestByRange(FIND_MY_SPAWNS);
     if (!spawn) return;
+
+    const roomMemory = Memory.rooms && Memory.rooms[creep.room.name];
+    if (roomMemory && roomMemory.restrictedArea) {
+      for (const p of roomMemory.restrictedArea) {
+        if (creep.pos.x === p.x && creep.pos.y === p.y) {
+          creep.travelTo(spawn, { range: 2 });
+          return;
+        }
+      }
+    }
     if (creep.pos.isNearTo(spawn)) {
       const demandNearby = spawn.pos
         .findInRange(FIND_STRUCTURES, 1, {


### PR DESCRIPTION
## Summary
- prioritize building containers, extensions, controller and buffer structures in order
- track restricted spawn tiles in hive mind and avoid them in movement utils
- allow up to 4 builders per construction site with memory tracking
- update documentation and roadmap
- add unit test for builder site assignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c22f00f0832794316ab19c9c553d