### PR TITLE
Implement HiveMind failsafe memory init

### DIFF
--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -42,3 +42,11 @@ its queue is empty.
     miners or allPurpose creeps die.
   - Restricted tiles around the spawn are stored in room memory so creeps avoid
     blocking it.
+
+## Failsafe Memory Initialization
+
+After a respawn or unexpected memory wipe the HiveMind may lack the data needed
+to plan tasks. When required sections such as `rooms` or `hive` are missing it
+logs a severity 5 message and schedules a one-time high priority task to
+recreate the baseline memory. The room is rescanned and HiveMind evaluations
+resume on the following tick.

--- a/manager.hivemind.js
+++ b/manager.hivemind.js
@@ -1,5 +1,9 @@
 const htm = require('./manager.htm');
 const spawnModule = require('./manager.hivemind.spawn');
+const scheduler = require('./scheduler');
+const memoryManager = require('./manager.memory');
+const roomManager = require('./manager.room');
+const statsConsole = require('console.console');
 
 const modules = [spawnModule];
 
@@ -14,6 +18,33 @@ const hivemind = {
     for (const roomName in Game.rooms) {
       const room = Game.rooms[roomName];
       if (!room.controller || !room.controller.my) continue;
+
+      // Verify essential memory exists, otherwise schedule emergency init
+      const missing = [];
+      if (!Memory.rooms || !Memory.rooms[roomName]) missing.push('room');
+      else if (!Memory.rooms[roomName].miningPositions) missing.push('mining');
+      if (!Memory.hive || !Memory.hive.clusters || !Memory.hive.clusters[roomName]) missing.push('hive');
+      if (!Memory.spawnQueue) missing.push('spawnQueue');
+      if (!Memory.stats) missing.push('stats');
+
+      if (missing.length > 0) {
+        statsConsole.log(`HiveMind missing memory for ${roomName}: ${missing.join(', ')}`, 5);
+        scheduler.addTask(
+          `emergencyInit_${roomName}`,
+          0,
+          () => {
+            const r = Game.rooms[roomName];
+            if (r) {
+              memoryManager.initializeRoomMemory(r);
+              memoryManager.initializeHiveMemory(r.name, r.name);
+              roomManager.scanRoom(r);
+            }
+          },
+          { highPriority: true, once: true },
+        );
+        // Skip normal modules this tick so memory can be prepared
+        continue;
+      }
 
       for (const mod of modules) {
         if (!mod.shouldRun || mod.shouldRun(room)) {

--- a/test/hivemindEmergency.test.js
+++ b/test/hivemindEmergency.test.js
@@ -1,0 +1,31 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const hivemind = require('../manager.hivemind');
+const scheduler = require('../scheduler');
+
+// Minimal constants to satisfy modules if they run
+global._ = require('lodash');
+
+describe('hivemind emergency initialization', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory();
+    scheduler.reset();
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find: () => [],
+    };
+    Memory.htm = { hive: { tasks: [] }, clusters: {}, colonies: {}, creeps: {} };
+    Memory.spawnQueue = [];
+    Memory.stats = {};
+    // intentionally omit Memory.rooms and Memory.hive to trigger failsafe
+  });
+
+  it('schedules emergency task when memory missing', function () {
+    hivemind.run();
+    const task = scheduler.highPriorityTasks.find(t => t.name === 'emergencyInit_W1N1');
+    expect(task).to.exist;
+    expect(task.once).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- add emergency memory init in `manager.hivemind`
- document failsafe in `docs/hivemind.md`
- test scheduling of emergency task

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c5ca0cdc8327a07491a0e52fe739