### PR TITLE
Implement energy demand evaluation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,10 @@
 - [x] Replacement miners requested before predecessors expire
 - [x] Reserved positions cleared on miner/allPurpose death
 
+### 🔄 Energy Demand Module (Prio 3)
+- [x] Record delivery performance for requesters
+- [ ] Evaluate metrics to spawn extra haulers when throughput is low
+
 ---
 
 ## 🛰️ Map Awareness – Hive's Gaze (Prio 3)

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -32,6 +32,9 @@ its queue is empty.
   construction site with a hard maximum of twelve. When no creeps remain the
   queue is purged and a bootstrap worker
   is scheduled so the colony can recover.
+- **demand** – Tracks energy deliveries. When average rates fall below
+  acceptable thresholds the module queues an additional hauler for the affected
+  colony. It only runs when flagged by a completed delivery.
   Modules can be added later for building, defense or expansion logic.
   The HiveMind also orders basic infrastructure:
   - Containers are planned as soon as the room is claimed (RCL1).

--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ const htm = require("manager.htm");
 const hivemind = require("manager.hivemind");
 const movementUtils = require("./utils.movement");
 
+const energyDemand = require("./manager.hivemind.demand");
 // HiveTravel installs travelTo on creeps
 
 let myStats = [];
@@ -143,6 +144,9 @@ scheduler.addTask("hivemind", 1, () => {
   hivemind.run();
 });
 
+scheduler.addTask("energyDemand", 1000, () => {
+  energyDemand.run();
+});
 // Core HTM execution task
 scheduler.addTask("htmRun", 1, () => {
   htm.run();

--- a/manager.hivemind.demand.js
+++ b/manager.hivemind.demand.js
@@ -1,0 +1,104 @@
+const scheduler = require('./scheduler');
+const statsConsole = require('console.console');
+const htm = require('./manager.htm');
+
+const ENERGY_PER_TICK_THRESHOLD = 1; // Delivery rate below which more haulers are spawned
+
+function initMemory() {
+  if (!Memory.demand) Memory.demand = { requesters: {}, runNextTick: false };
+  if (!Memory.demand.requesters) Memory.demand.requesters = {};
+}
+
+function updateAverage(oldAvg, count, value) {
+  return (oldAvg * (count - 1) + value) / count;
+}
+
+const demandModule = {
+  /**
+   * Record delivery metrics for a requester and flag evaluation
+   * @param {string} id - Target structure id
+   * @param {number} ticks - Ticks spent delivering
+   * @param {number} amount - Energy delivered
+   * @param {string} room - Room where the requester resides
+   */
+  recordDelivery(id, ticks, amount, room) {
+    initMemory();
+    const data = Memory.demand.requesters[id] || {
+      lastTickTime: 0,
+      averageTickTime: 0,
+      lastEnergy: 0,
+      averageEnergy: 0,
+      deliveries: 0,
+      room,
+    };
+    data.room = room;
+    data.deliveries += 1;
+    data.lastTickTime = ticks;
+    data.lastEnergy = amount;
+    data.averageTickTime = updateAverage(
+      data.averageTickTime,
+      data.deliveries,
+      ticks,
+    );
+    data.averageEnergy = updateAverage(
+      data.averageEnergy,
+      data.deliveries,
+      amount,
+    );
+    Memory.demand.requesters[id] = data;
+    Memory.demand.runNextTick = true;
+    scheduler.requestTaskUpdate('energyDemand');
+    statsConsole.log(`Recorded delivery for ${id}: ${amount} energy in ${ticks} ticks`, 3);
+  },
+
+  /** Check flag and evaluate demand once */
+  shouldRun() {
+    initMemory();
+    return Memory.demand.runNextTick;
+  },
+
+  run() {
+    if (!this.shouldRun()) return;
+    const requesters = Memory.demand.requesters;
+    const roomsNeedingHaulers = new Set();
+    for (const id in requesters) {
+      const data = requesters[id];
+      const rate =
+        data.averageTickTime > 0
+          ? data.averageEnergy / data.averageTickTime
+          : 0;
+      statsConsole.log(
+        `Demand ${id}: avg ${data.averageEnergy.toFixed(1)} energy / ${data.averageTickTime.toFixed(1)} ticks`,
+        2,
+      );
+      if (rate < ENERGY_PER_TICK_THRESHOLD && data.room) {
+        roomsNeedingHaulers.add(data.room);
+      }
+    }
+
+    for (const roomName of roomsNeedingHaulers) {
+      htm.init();
+      if (
+        !htm.hasTask(htm.LEVELS.COLONY, roomName, 'spawnHauler', 'spawnManager')
+      ) {
+        htm.addColonyTask(
+          roomName,
+          'spawnHauler',
+          { role: 'hauler' },
+          2,
+          20,
+          1,
+          'spawnManager',
+        );
+        statsConsole.log(
+          `Energy demand high in ${roomName}: queued extra hauler`,
+          2,
+        );
+      }
+    }
+
+    Memory.demand.runNextTick = false;
+  },
+};
+
+module.exports = demandModule;

--- a/test/demandRecord.test.js
+++ b/test/demandRecord.test.js
@@ -1,0 +1,38 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const demand = require('../manager.hivemind.demand');
+
+describe('demand recordDelivery', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory({ stats: { logs: [] } });
+  });
+
+  it('updates averages and flags next run', function () {
+    demand.recordDelivery('s1', 10, 100, 'W1N1');
+    demand.recordDelivery('s1', 20, 50, 'W1N1');
+
+    const data = Memory.demand.requesters['s1'];
+    expect(data.lastTickTime).to.equal(20);
+    expect(data.lastEnergy).to.equal(50);
+    expect(data.deliveries).to.equal(2);
+    expect(data.averageTickTime).to.equal(15);
+    expect(data.averageEnergy).to.equal(75);
+    expect(Memory.demand.runNextTick).to.be.true;
+
+    demand.run();
+    expect(Memory.demand.runNextTick).to.be.false;
+  });
+
+  it('queues hauler when delivery rate low', function () {
+    const htm = require('../manager.htm');
+    htm.init();
+    Game.rooms['W1N1'] = { name: 'W1N1' };
+    demand.recordDelivery('target1', 100, 20, 'W1N1');
+    demand.run();
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    const haulTask = tasks.find(t => t.name === 'spawnHauler');
+    expect(haulTask).to.exist;
+  });
+});


### PR DESCRIPTION
## Summary
- record delivery metrics with room info and flag next evaluation
- queue hauler spawn if average delivery rate drops below threshold
- trigger demand module via scheduler with long interval and run on task completion
- document the new HiveMind demand module
- add tests covering hauler spawn logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68456f9430448327abb89e9de6beb934