### PR TITLE
Implement spawn queue priority

### DIFF
--- a/docs/spawnQueue.md
+++ b/docs/spawnQueue.md
@@ -13,11 +13,12 @@ The spawn queue decouples creep requests from immediate spawning. Managers or HT
   memory: { role: 'miner' },
   spawnId: '5abc123',
   ticksToSpawn: 0, // lower means sooner
-  energyRequired: 300
+  energyRequired: 300,
+  priority: 2
 }
 ```
 
-`requestId` combines the current tick with an incrementing counter to ensure uniqueness. The queue is sorted by `ticksToSpawn`, so older or urgent entries spawn first.
+`requestId` combines the current tick with an incrementing counter to ensure uniqueness. The queue is sorted by `priority` (lower is higher priority) and then `ticksToSpawn`, so urgent entries spawn first.
 
 ## Processing
 
@@ -26,10 +27,11 @@ Use `spawnQueue.processQueue(spawn)` each tick. It checks energy and spawns the 
 ## Adding requests
 
 ```
-spawnQueue.addToQueue('miner', room.name, body, { role: 'miner' }, spawn.id);
+spawnQueue.addToQueue('miner', room.name, body, { role: 'miner' }, spawn.id, 0, 2);
 ```
 
 Requests can include a `ticksToSpawn` delay, allowing future scheduling.
+The optional `priority` parameter (default `5`) lets high priority creeps spawn sooner.
 
 ### Positional memory requirements
 

--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -7,6 +7,15 @@ const { calculateCollectionTicks } = require("utils.energy");
 const logger = require("./logger");
 const energyRequests = require("./manager.energyRequests");
 
+// Default spawn priorities per role
+const ROLE_PRIORITY = {
+  allPurpose: 1,
+  miner: 2,
+  hauler: 3,
+  upgrader: 5,
+  builder: 5,
+};
+
 // Direction deltas for checking adjacent tiles around a spawn
 const directionDelta = {
   [TOP]: { x: 0, y: -1 },
@@ -207,6 +216,8 @@ const spawnManager = {
               collectionTicks,
             },
             spawn.id,
+            0,
+            ROLE_PRIORITY.miner,
           );
           return bodyParts.length;
         }
@@ -229,6 +240,8 @@ const spawnManager = {
       bodyParts,
       { role: "hauler" },
       spawn.id,
+      0,
+      ROLE_PRIORITY.hauler,
     );
     logger.log(
       "spawnManager",
@@ -250,6 +263,8 @@ const spawnManager = {
       bodyParts,
       { role: "upgrader" },
       spawn.id,
+      0,
+      ROLE_PRIORITY.upgrader,
     );
     logger.log(
       "spawnManager",
@@ -271,6 +286,8 @@ const spawnManager = {
       bodyParts,
       { role: "builder" },
       spawn.id,
+      0,
+      ROLE_PRIORITY.builder,
     );
     logger.log(
       "spawnManager",
@@ -315,6 +332,8 @@ const spawnManager = {
           bodyParts,
           creepMemory,
           spawn.id,
+          0,
+          ROLE_PRIORITY.allPurpose,
         );
         return bodyParts.length;
       }
@@ -341,6 +360,8 @@ const spawnManager = {
         },
       },
       spawn.id,
+      0,
+      ROLE_PRIORITY.allPurpose,
     );
     return bodyParts.length;
   },
@@ -568,7 +589,15 @@ const spawnManager = {
             size = this.spawnAllPurpose(spawn, room, task.data.panic);
           } else {
             const body = dna.getBodyParts(role, room, task.data.panic);
-            spawnQueue.addToQueue(role, room.name, body, { role }, spawn.id);
+            spawnQueue.addToQueue(
+              role,
+              room.name,
+              body,
+              { role },
+              spawn.id,
+              0,
+              ROLE_PRIORITY[role] || 5,
+            );
             size = body.length;
           }
           if (size > 0) {

--- a/test/spawnQueue.test.js
+++ b/test/spawnQueue.test.js
@@ -14,6 +14,7 @@ describe('spawnQueue.clearRoom', function() {
     globals.resetGame();
     globals.resetMemory();
     spawnQueue.queue = [];
+    Memory.nextSpawnRequestId = 0;
   });
 
   it('removes queued spawns for specific room', function() {
@@ -42,5 +43,27 @@ describe('spawnQueue.addToQueue validation', function() {
       's1',
     );
     expect(spawnQueue.queue.length).to.equal(0);
+  });
+});
+
+describe('spawnQueue priority handling', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawnQueue.queue = [];
+    Memory.nextSpawnRequestId = 0;
+  });
+
+  it('returns highest priority request first', function() {
+    spawnQueue.addToQueue('upgrader', 'W1N1', [WORK], { role: 'upgrader' }, 's1', 0, 5);
+    spawnQueue.addToQueue('hauler', 'W1N1', [CARRY, MOVE], { role: 'hauler' }, 's1', 0, 3);
+    spawnQueue.addToQueue('miner', 'W1N1', [WORK, MOVE], { role: 'miner' }, 's1', 0, 2);
+
+    const next = spawnQueue.getNextSpawn('s1');
+    expect(next.category).to.equal('miner');
+    spawnQueue.removeSpawnFromQueue(next.requestId);
+
+    const next2 = spawnQueue.getNextSpawn('s1');
+    expect(next2.category).to.equal('hauler');
   });
 });


### PR DESCRIPTION
## Summary
- introduce `ROLE_PRIORITY` for deterministic spawn order
- add priority parameter to spawn queue and update queue sorting logic
- document spawn queue priority
- validate priority sorting in test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458a2e1064832795f46e6dba6dce0f