### PR TITLE
Improve initial spawn order and hauler demand

### DIFF
--- a/docs/spawnQueue.md
+++ b/docs/spawnQueue.md
@@ -13,11 +13,12 @@ The spawn queue decouples creep requests from immediate spawning. Managers or HT
   memory: { role: 'miner' },
   spawnId: '5abc123',
   ticksToSpawn: 0, // lower means sooner
-  energyRequired: 300
+  energyRequired: 300,
+  priority: 2
 }
 ```
 
-`requestId` combines the current tick with an incrementing counter to ensure uniqueness. The queue is sorted by `ticksToSpawn`, so older or urgent entries spawn first.
+`requestId` combines the current tick with an incrementing counter to ensure uniqueness. The queue is sorted by `priority` (lower is higher priority) and then `ticksToSpawn`, so urgent entries spawn first.
 
 ## Processing
 
@@ -26,10 +27,11 @@ Use `spawnQueue.processQueue(spawn)` each tick. It checks energy and spawns the 
 ## Adding requests
 
 ```
-spawnQueue.addToQueue('miner', room.name, body, { role: 'miner' }, spawn.id);
+spawnQueue.addToQueue('miner', room.name, body, { role: 'miner' }, spawn.id, 0, 2);
 ```
 
 Requests can include a `ticksToSpawn` delay, allowing future scheduling.
+The optional `priority` parameter (default `5`) lets high priority creeps spawn sooner.
 
 ### Positional memory requirements
 

--- a/manager.hivemind.demand.js
+++ b/manager.hivemind.demand.js
@@ -1,12 +1,21 @@
 const scheduler = require('./scheduler');
 const statsConsole = require('console.console');
 const htm = require('./manager.htm');
+const spawnQueue = require('./manager.spawnQueue');
+const _ = require('lodash');
 
 const ENERGY_PER_TICK_THRESHOLD = 1; // Delivery rate below which more haulers are spawned
 
 function initMemory() {
-  if (!Memory.demand) Memory.demand = { requesters: {}, runNextTick: false };
-  if (!Memory.demand.requesters) Memory.demand.requesters = {};
+  if (!Memory.demand) Memory.demand = { rooms: {} };
+}
+
+function getRoomMem(roomName) {
+  initMemory();
+  if (!Memory.demand.rooms[roomName]) {
+    Memory.demand.rooms[roomName] = { requesters: {}, runNextTick: false };
+  }
+  return Memory.demand.rooms[roomName];
 }
 
 function updateAverage(oldAvg, count, value) {
@@ -22,16 +31,14 @@ const demandModule = {
    * @param {string} room - Room where the requester resides
    */
   recordDelivery(id, ticks, amount, room) {
-    initMemory();
-    const data = Memory.demand.requesters[id] || {
+    const roomMem = getRoomMem(room);
+    const data = roomMem.requesters[id] || {
       lastTickTime: 0,
       averageTickTime: 0,
       lastEnergy: 0,
       averageEnergy: 0,
       deliveries: 0,
-      room,
     };
-    data.room = room;
     data.deliveries += 1;
     data.lastTickTime = ticks;
     data.lastEnergy = amount;
@@ -45,55 +52,129 @@ const demandModule = {
       data.deliveries,
       amount,
     );
-    Memory.demand.requesters[id] = data;
-    Memory.demand.runNextTick = true;
+    roomMem.requesters[id] = data;
+    roomMem.runNextTick = true;
     scheduler.requestTaskUpdate('energyDemand');
     statsConsole.log(`Recorded delivery for ${id}: ${amount} energy in ${ticks} ticks`, 3);
   },
 
-  /** Check flag and evaluate demand once */
+  /** Check if demand evaluation should run */
   shouldRun() {
     initMemory();
-    return Memory.demand.runNextTick;
+    for (const roomName in Memory.demand.rooms) {
+      if (Memory.demand.rooms[roomName].runNextTick) return true;
+    }
+    // Fallback: no haulers but miners present
+    for (const roomName in Game.rooms) {
+      const room = Game.rooms[roomName];
+      if (!room.controller || !room.controller.my) continue;
+      const miners = _.filter(
+        Game.creeps,
+        c => c.memory.role === 'miner' && c.room.name === roomName,
+      ).length;
+      const haulers = _.filter(
+        Game.creeps,
+        c => c.memory.role === 'hauler' && c.room.name === roomName,
+      ).length;
+      if (miners > 0 && haulers === 0) return true;
+    }
+    return false;
   },
 
   run() {
     if (!this.shouldRun()) return;
-    const requesters = Memory.demand.requesters;
+
     const roomsNeedingHaulers = new Set();
-    for (const id in requesters) {
-      const data = requesters[id];
-      const rate =
-        data.averageTickTime > 0
-          ? data.averageEnergy / data.averageTickTime
-          : 0;
-      statsConsole.log(
-        `Demand ${id}: avg ${data.averageEnergy.toFixed(1)} energy / ${data.averageTickTime.toFixed(1)} ticks`,
-        2,
-      );
-      if (rate < ENERGY_PER_TICK_THRESHOLD && data.room) {
-        roomsNeedingHaulers.add(data.room);
+
+    for (const roomName in Memory.demand.rooms) {
+      const roomMem = Memory.demand.rooms[roomName];
+      const requesters = roomMem.requesters;
+      for (const id in requesters) {
+        const data = requesters[id];
+        const rate =
+          data.averageTickTime > 0
+            ? data.averageEnergy / data.averageTickTime
+            : 0;
+        statsConsole.log(
+          `Demand ${id}: avg ${data.averageEnergy.toFixed(1)} energy / ${data.averageTickTime.toFixed(1)} ticks`,
+          2,
+        );
+        if (rate < ENERGY_PER_TICK_THRESHOLD) {
+          roomsNeedingHaulers.add(roomName);
+        }
+      }
+      roomMem.runNextTick = false;
+    }
+
+    // Evaluate rooms without delivery data but with miners present
+    for (const roomName in Game.rooms) {
+      const room = Game.rooms[roomName];
+      if (!room.controller || !room.controller.my) continue;
+      const minersAlive = _.filter(
+        Game.creeps,
+        c => c.memory.role === 'miner' && c.room.name === roomName,
+      ).length;
+      const queuedMiners = spawnQueue.queue.filter(
+        q => q.room === roomName && q.memory.role === 'miner',
+      ).length;
+      const haulersAlive = _.filter(
+        Game.creeps,
+        c => c.memory.role === 'hauler' && c.room.name === roomName,
+      ).length;
+      const queuedHaulers = spawnQueue.queue.filter(
+        q => q.room === roomName && q.memory.role === 'hauler',
+      ).length;
+      const container = htm._getContainer(htm.LEVELS.COLONY, roomName);
+      const task = container && container.tasks
+        ? container.tasks.find(t => t.name === 'spawnHauler' && t.manager === 'spawnManager')
+        : null;
+      const totalMiners = minersAlive + queuedMiners;
+      const totalHaulers = haulersAlive + queuedHaulers + (task ? task.amount || 0 : 0);
+      if (totalMiners >= 2 && totalHaulers < 2) {
+        roomsNeedingHaulers.add(roomName);
+      } else if (totalMiners > 0 && totalHaulers === 0) {
+        roomsNeedingHaulers.add(roomName);
       }
     }
 
     for (const roomName of roomsNeedingHaulers) {
       htm.init();
-      if (
-        !htm.hasTask(htm.LEVELS.COLONY, roomName, 'spawnHauler', 'spawnManager')
-      ) {
-        htm.addColonyTask(
-          roomName,
-          'spawnHauler',
-          { role: 'hauler' },
-          2,
-          20,
-          1,
-          'spawnManager',
-        );
-        statsConsole.log(
-          `Energy demand high in ${roomName}: queued extra hauler`,
-          2,
-        );
+      const container = htm._getContainer(htm.LEVELS.COLONY, roomName);
+      const existing = container.tasks.find(
+        t => t.name === 'spawnHauler' && t.manager === 'spawnManager',
+      );
+      const haulersAlive = _.filter(
+        Game.creeps,
+        c => c.memory.role === 'hauler' && c.room.name === roomName,
+      ).length;
+      const queuedHaulers = spawnQueue.queue.filter(
+        q => q.room === roomName && q.memory.role === 'hauler',
+      ).length;
+      const currentAmount =
+        haulersAlive + queuedHaulers + (existing ? existing.amount || 0 : 0);
+      let required = 1;
+      const minersAlive = _.filter(
+        Game.creeps,
+        c => c.memory.role === 'miner' && c.room.name === roomName,
+      ).length;
+      const queuedMiners = spawnQueue.queue.filter(
+        q => q.room === roomName && q.memory.role === 'miner',
+      ).length;
+      if (minersAlive + queuedMiners >= 2) required = 2;
+      const toQueue = Math.max(0, required - currentAmount);
+      if (toQueue > 0) {
+        if (existing) existing.amount += toQueue;
+        else
+          htm.addColonyTask(
+            roomName,
+            'spawnHauler',
+            { role: 'hauler' },
+            2,
+            20,
+            toQueue,
+            'spawnManager',
+          );
+        statsConsole.log(`Energy demand high in ${roomName}: queued hauler`, 2);
       }
       const room = Game.rooms[roomName];
       if (room) {
@@ -101,8 +182,6 @@ const demandModule = {
         roles.evaluateRoom(room);
       }
     }
-
-    Memory.demand.runNextTick = false;
   },
 };
 

--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -57,7 +57,10 @@ const spawnModule = {
     // Panic: no creeps present
     const myCreeps = _.filter(Game.creeps, (c) => c.my && c.room.name === roomName);
     const container = htm._getContainer(htm.LEVELS.COLONY, roomName);
-    if (myCreeps.length === 0) {
+    const spawning = room
+      .find(FIND_MY_SPAWNS)
+      .some((s) => s.memory && s.memory.currentSpawnRole);
+    if (myCreeps.length === 0 && !spawning) {
       // Emergency: purge existing queue and force a bootstrap creep
       const removed = spawnQueue.clearRoom(roomName);
       if (!taskExists(roomName, 'spawnBootstrap', 'spawnManager')) {
@@ -84,7 +87,7 @@ const spawnModule = {
     { task: 'spawnMiner', data: { role: 'miner' }, priority: 1 },
     { task: 'spawnHauler', data: { role: 'hauler' }, priority: 2 },
     { task: 'spawnHauler', data: { role: 'hauler' }, priority: 2 },
-    { task: 'spawnUpgrader', data: { role: 'upgrader' }, priority: 3 },
+    { task: 'spawnBuilder', data: { role: 'builder' }, priority: 5 },
   ];
 
   const initialRoles = [
@@ -93,7 +96,7 @@ const spawnModule = {
     'miner',
     'hauler',
     'hauler',
-    'upgrader',
+    'builder',
   ];
 
   const queuedInitial = spawnQueue.queue.filter(
@@ -110,8 +113,16 @@ const spawnModule = {
           .reduce((sum, t) => sum + (t.amount || 1), 0)
       : 0;
 
-    const aliveInitial = myCreeps.filter((c) => initialRoles.includes(c.memory.role)).length;
-    const totalPlanned = aliveInitial + queuedInitial + tasksInitial;
+  const spawningInitial = room
+    .find(FIND_MY_SPAWNS)
+    .reduce((sum, s) => {
+      const role = s.memory && s.memory.currentSpawnRole;
+      if (role && initialRoles.includes(role)) return sum + 1;
+      return sum;
+    }, 0);
+
+  const aliveInitial = myCreeps.filter((c) => initialRoles.includes(c.memory.role)).length;
+  const totalPlanned = aliveInitial + spawningInitial + queuedInitial + tasksInitial;
 
     if (room.controller.level === 1 && totalPlanned < initialOrder.length) {
       const nextEntry = initialOrder[totalPlanned];

--- a/test/demandFallback.test.js
+++ b/test/demandFallback.test.js
@@ -1,0 +1,31 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const demand = require('../manager.hivemind.demand');
+const htm = require('../manager.htm');
+
+describe('demand fallback hauler spawn', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory({ stats: { logs: [] } });
+    htm.init();
+    Memory.htm.colonies['W1N1'] = { tasks: [] };
+    demand.shouldRun();
+  });
+
+  it('queues hauler when miners exist but no haulers', function () {
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true, pos: { findInRange: () => [] } },
+      find: () => [],
+    };
+    Game.creeps = {
+      m1: { memory: { role: 'miner' }, room: { name: 'W1N1' } },
+      m2: { memory: { role: 'miner' }, room: { name: 'W1N1' } },
+    };
+    demand.run();
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    const haulTask = tasks.find(t => t.name === 'spawnHauler');
+    expect(haulTask).to.exist;
+  });
+});

--- a/test/demandRecord.test.js
+++ b/test/demandRecord.test.js
@@ -7,28 +7,40 @@ describe('demand recordDelivery', function () {
   beforeEach(function () {
     globals.resetGame();
     globals.resetMemory({ stats: { logs: [] } });
+    const htm = require('../manager.htm');
+    htm.init();
+    Memory.htm.colonies['W1N1'] = { tasks: [] };
   });
 
   it('updates averages and flags next run', function () {
     demand.recordDelivery('s1', 10, 100, 'W1N1');
     demand.recordDelivery('s1', 20, 50, 'W1N1');
 
-    const data = Memory.demand.requesters['s1'];
+    const data = Memory.demand.rooms['W1N1'].requesters['s1'];
     expect(data.lastTickTime).to.equal(20);
     expect(data.lastEnergy).to.equal(50);
     expect(data.deliveries).to.equal(2);
     expect(data.averageTickTime).to.equal(15);
     expect(data.averageEnergy).to.equal(75);
-    expect(Memory.demand.runNextTick).to.be.true;
+    expect(Memory.demand.rooms['W1N1'].runNextTick).to.be.true;
 
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true, pos: { findInRange: () => [] } },
+      find: () => [],
+    };
     demand.run();
-    expect(Memory.demand.runNextTick).to.be.false;
+    expect(Memory.demand.rooms['W1N1'].runNextTick).to.be.false;
   });
 
   it('queues hauler when delivery rate low', function () {
     const htm = require('../manager.htm');
     htm.init();
-    Game.rooms['W1N1'] = { name: 'W1N1' };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true, pos: { findInRange: () => [] } },
+      find: () => [],
+    };
     demand.recordDelivery('target1', 100, 20, 'W1N1');
     demand.run();
     const tasks = Memory.htm.colonies['W1N1'].tasks;

--- a/test/hivemindSpawn.test.js
+++ b/test/hivemindSpawn.test.js
@@ -71,14 +71,14 @@ describe('hivemind spawn module', function () {
     htm.init();
   });
 
-  it('queues initial spawn order before builders', function () {
+  it('queues initial spawn order including builder', function () {
     const order = [
       'spawnBootstrap',
       'spawnMiner',
       'spawnMiner',
       'spawnHauler',
       'spawnHauler',
-      'spawnUpgrader',
+      'spawnBuilder',
     ];
     for (let i = 0; i < order.length; i++) {
       spawnModule.run(Game.rooms['W1N1']);
@@ -90,9 +90,34 @@ describe('hivemind spawn module', function () {
       spawnBootstrap: 1,
       spawnMiner: 2,
       spawnHauler: 2,
-      spawnUpgrader: 1,
+      spawnBuilder: 1,
     });
-    expect(Object.keys(counts)).to.not.include('spawnBuilder');
+  });
+
+  it('considers spawn in progress for initial ordering', function () {
+    // First tick queues bootstrap
+    spawnModule.run(Game.rooms['W1N1']);
+    Memory.htm.colonies['W1N1'].tasks = [];
+    spawnQueue.queue = [];
+    const spawnObj = { id: 's1', pos: { getRangeTo: () => 5 }, memory: { currentSpawnRole: 'allPurpose' }, spawning: { name: 'ap1' } };
+    Game.rooms['W1N1'].find = (type) => {
+      if (type === FIND_HOSTILE_CREEPS) return [];
+      if (type === FIND_SOURCES) {
+        return [
+          {
+            id: 'source1',
+            pos: { x: 5, y: 5, roomName: 'W1N1', getRangeTo: () => 0 },
+          },
+        ];
+      }
+      if (type === FIND_MY_SPAWNS) return [spawnObj];
+      return [];
+    };
+
+    // Second tick should queue the miner as next entry
+    spawnModule.run(Game.rooms['W1N1']);
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    expect(tasks.some(t => t.name === 'spawnMiner')).to.be.true;
   });
 
   it('adjusts hauler amount based on non-hauler ratio', function () {
@@ -102,7 +127,7 @@ describe('hivemind spawn module', function () {
       'spawnMiner',
       'spawnHauler',
       'spawnHauler',
-      'spawnUpgrader',
+      'spawnBuilder',
     ];
     for (let i = 0; i < order.length; i++) {
       spawnModule.run(Game.rooms['W1N1']);
@@ -127,7 +152,7 @@ describe('hivemind spawn module', function () {
       'spawnMiner',
       'spawnHauler',
       'spawnHauler',
-      'spawnUpgrader',
+      'spawnBuilder',
     ];
     for (let i = 0; i < order.length; i++) {
       spawnModule.run(Game.rooms['W1N1']);

--- a/test/spawnQueue.test.js
+++ b/test/spawnQueue.test.js
@@ -14,6 +14,7 @@ describe('spawnQueue.clearRoom', function() {
     globals.resetGame();
     globals.resetMemory();
     spawnQueue.queue = [];
+    Memory.nextSpawnRequestId = 0;
   });
 
   it('removes queued spawns for specific room', function() {
@@ -42,5 +43,27 @@ describe('spawnQueue.addToQueue validation', function() {
       's1',
     );
     expect(spawnQueue.queue.length).to.equal(0);
+  });
+});
+
+describe('spawnQueue priority handling', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawnQueue.queue = [];
+    Memory.nextSpawnRequestId = 0;
+  });
+
+  it('returns highest priority request first', function() {
+    spawnQueue.addToQueue('upgrader', 'W1N1', [WORK], { role: 'upgrader' }, 's1', 0, 5);
+    spawnQueue.addToQueue('hauler', 'W1N1', [CARRY, MOVE], { role: 'hauler' }, 's1', 0, 3);
+    spawnQueue.addToQueue('miner', 'W1N1', [WORK, MOVE], { role: 'miner' }, 's1', 0, 2);
+
+    const next = spawnQueue.getNextSpawn('s1');
+    expect(next.category).to.equal('miner');
+    spawnQueue.removeSpawnFromQueue(next.requestId);
+
+    const next2 = spawnQueue.getNextSpawn('s1');
+    expect(next2.category).to.equal('hauler');
   });
 });


### PR DESCRIPTION
## Summary
- ensure builder finishes the bootstrap spawn order
- store demand metrics per room and add fallback hauler checks
- update demand logic to queue haulers when miners exist but no haulers
- adjust tests for builder ordering and new demand memory
- add regression test for hauler fallback

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68458a2e1064832795f46e6dba6dce0f