### PR TITLE
Implement demand tracking and HTM cleanup

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,6 +84,7 @@
 ### 🔄 Energy Demand Module (Prio 3)
 - [x] Record delivery performance for requesters
 - [ ] Evaluate metrics to spawn extra haulers when throughput is low
+- [ ] Persist aggregated demand and hauler supply metrics
 
 ---
 

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -34,9 +34,11 @@ its queue is empty.
   recover.
 - **demand** – Tracks energy deliveries. When average rates fall below
   acceptable thresholds the module queues an additional hauler for the affected
-  colony. Delivery statistics are stored per-room under `Memory.demand.rooms` and
-  the module migrates legacy flat layouts automatically. It only runs when
-  flagged by a completed delivery.
+  colony. Delivery statistics are stored per-room under `Memory.demand.rooms`
+  along with aggregate `totals` for outstanding demand and current hauler
+  supply. The module migrates legacy flat layouts automatically. It only runs
+  when flagged by a completed delivery but maintains these totals every tick
+  so other systems can react without recalculating.
   Modules can be added later for building, defense or expansion logic.
   The HiveMind also orders basic infrastructure:
   - Containers are planned as soon as the room is claimed (RCL1).

--- a/main.js
+++ b/main.js
@@ -115,6 +115,14 @@ scheduler.addTask("clearMemory", 100, () => {
       }
       logger.log('memory', `Clearing memory of dead creep: ${name}`, 2);
       delete Memory.creeps[name];
+      if (
+        Memory.htm &&
+        Memory.htm.creeps &&
+        Memory.htm.creeps[name] &&
+        (!Memory.htm.creeps[name].tasks || Memory.htm.creeps[name].tasks.length === 0)
+      ) {
+        delete Memory.htm.creeps[name];
+      }
       removed = true;
     }
   }

--- a/manager.energyRequests.js
+++ b/manager.energyRequests.js
@@ -1,5 +1,6 @@
 const htm = require('./manager.htm');
 const statsConsole = require('console.console');
+const demand = require('./manager.hivemind.demand');
 
 const HAULER_CAPACITY = 600;
 
@@ -30,6 +31,8 @@ function ensureTask(structure) {
       'hauler',
     );
     statsConsole.log(`Energy request for ${structure.structureType} ${id} (${needed})`, 3);
+    const roomName = (structure.room && structure.room.name) || structure.pos.roomName;
+    demand.recordRequest(id, needed, roomName);
   } else {
     task.data.amount = needed;
   }
@@ -63,6 +66,8 @@ function ensureContainerTask(structure) {
       'hauler',
     );
     statsConsole.log(`Energy request for container ${id} (${needed})`, 3);
+    const roomName = (structure.room && structure.room.name) || structure.pos.roomName;
+    demand.recordRequest(id, needed, roomName);
   } else {
     task.data.amount = needed;
   }

--- a/manager.hivemind.demand.js
+++ b/manager.hivemind.demand.js
@@ -8,14 +8,21 @@ const ENERGY_PER_TICK_THRESHOLD = 1; // Delivery rate below which more haulers a
 
 function initMemory() {
   if (!Memory.demand || !Memory.demand.rooms) {
-    Memory.demand = { rooms: {} };
+    Memory.demand = { rooms: {}, globalTotals: { demand: 0, supply: 0 } };
+  } else if (!Memory.demand.globalTotals) {
+    Memory.demand.globalTotals = { demand: 0, supply: 0 };
   }
 }
 
 function getRoomMem(roomName) {
   initMemory();
   if (!Memory.demand.rooms[roomName]) {
-    Memory.demand.rooms[roomName] = { requesters: {}, runNextTick: false };
+    Memory.demand.rooms[roomName] = {
+      requesters: {},
+      deliverers: {},
+      totals: { demand: 0, supply: 0 },
+      runNextTick: false,
+    };
   }
   return Memory.demand.rooms[roomName];
 }
@@ -26,13 +33,36 @@ function updateAverage(oldAvg, count, value) {
 
 const demandModule = {
   /**
+   * Record an energy request so totals and averages remain accurate.
+   * @param {string} id - Requesting creep or structure id
+   * @param {number} amount - Energy requested
+   * @param {string} room - Room where the requester resides
+   */
+  recordRequest(id, amount, room) {
+    const roomMem = getRoomMem(room);
+    const data = roomMem.requesters[id] || {
+      requests: 0,
+      lastRequestTick: 0,
+      averageRequested: 0,
+    };
+    data.requests += 1;
+    data.lastRequestTick = Game.time;
+    data.lastEnergyRequested = amount;
+    data.averageRequested = updateAverage(
+      data.averageRequested || 0,
+      data.requests,
+      amount,
+    );
+    roomMem.requesters[id] = data;
+  },
+  /**
    * Record delivery metrics for a requester and flag evaluation
    * @param {string} id - Target structure id
    * @param {number} ticks - Ticks spent delivering
    * @param {number} amount - Energy delivered
    * @param {string} room - Room where the requester resides
    */
-  recordDelivery(id, ticks, amount, room) {
+  recordDelivery(id, ticks, amount, room, deliverer = null) {
     const roomMem = getRoomMem(room);
     const data = roomMem.requesters[id] || {
       lastTickTime: 0,
@@ -55,6 +85,31 @@ const demandModule = {
       amount,
     );
     roomMem.requesters[id] = data;
+    roomMem.totals.supply += amount;
+
+    if (deliverer) {
+      const hauler = roomMem.deliverers[deliverer] || {
+        lastTickTime: 0,
+        averageTickTime: 0,
+        lastEnergy: 0,
+        averageEnergy: 0,
+        deliveries: 0,
+      };
+      hauler.deliveries += 1;
+      hauler.lastTickTime = ticks;
+      hauler.lastEnergy = amount;
+      hauler.averageTickTime = updateAverage(
+        hauler.averageTickTime,
+        hauler.deliveries,
+        ticks,
+      );
+      hauler.averageEnergy = updateAverage(
+        hauler.averageEnergy,
+        hauler.deliveries,
+        amount,
+      );
+      roomMem.deliverers[deliverer] = hauler;
+    }
     roomMem.runNextTick = true;
     scheduler.requestTaskUpdate('energyDemand');
     statsConsole.log(`Recorded delivery for ${id}: ${amount} energy in ${ticks} ticks`, 3);
@@ -84,6 +139,48 @@ const demandModule = {
   },
 
   run() {
+    initMemory();
+
+    Memory.demand.globalTotals.demand = 0;
+    Memory.demand.globalTotals.supply = 0;
+
+    for (const roomName in Game.rooms) {
+      const room = Game.rooms[roomName];
+      if (!room.controller || !room.controller.my) continue;
+      const roomMem = getRoomMem(roomName);
+
+      let demandAmount = 0;
+      if (Memory.htm && Memory.htm.creeps) {
+        for (const id in Memory.htm.creeps) {
+          const container = Memory.htm.creeps[id];
+          if (!container.tasks) continue;
+          for (const task of container.tasks) {
+            if (
+              task.name === 'deliverEnergy' &&
+              task.manager === 'hauler' &&
+              task.data &&
+              task.data.pos &&
+              task.data.pos.roomName === roomName
+            ) {
+              if (task.data.amount !== undefined) {
+                demandAmount += task.data.amount;
+              }
+            }
+          }
+        }
+      }
+      roomMem.totals.demand = demandAmount;
+      Memory.demand.globalTotals.demand += demandAmount;
+
+      const haulers = _.filter(
+        Game.creeps,
+        c => c.memory.role === 'hauler' && c.room.name === roomName,
+      );
+      const supply = _.sumBy(haulers, h => h.store[RESOURCE_ENERGY] || 0);
+      roomMem.totals.supply = supply;
+      Memory.demand.globalTotals.supply += supply;
+    }
+
     if (!this.shouldRun()) return;
 
     const roomsNeedingHaulers = new Set();

--- a/role.builder.js
+++ b/role.builder.js
@@ -30,6 +30,8 @@ function requestEnergy(creep) {
     1,
     'hauler',
   );
+  const demand = require('./manager.hivemind.demand');
+  demand.recordRequest(creep.name, creep.store.getCapacity ? creep.store.getCapacity() : 0, creep.room.name);
 }
 
 /**

--- a/role.hauler.js
+++ b/role.hauler.js
@@ -100,6 +100,7 @@ module.exports = {
               Game.time - creep.memory.task.startTime,
               creep.memory.task.initial,
               target.room.name,
+              creep.name,
             );
             delete creep.memory.task;
           }

--- a/role.upgrader.js
+++ b/role.upgrader.js
@@ -55,6 +55,8 @@ function requestEnergy(creep) {
     1,
     'hauler',
   );
+  const demand = require('./manager.hivemind.demand');
+  demand.recordRequest(creep.name, creep.store.getCapacity ? creep.store.getCapacity() : 0, creep.room.name);
 }
 
 const roleUpgrader = {

--- a/test/demandRecord.test.js
+++ b/test/demandRecord.test.js
@@ -13,8 +13,8 @@ describe('demand recordDelivery', function () {
   });
 
   it('updates averages and flags next run', function () {
-    demand.recordDelivery('s1', 10, 100, 'W1N1');
-    demand.recordDelivery('s1', 20, 50, 'W1N1');
+    demand.recordDelivery('s1', 10, 100, 'W1N1', 'h1');
+    demand.recordDelivery('s1', 20, 50, 'W1N1', 'h1');
 
     const data = Memory.demand.rooms['W1N1'].requesters['s1'];
     expect(data.lastTickTime).to.equal(20);
@@ -41,7 +41,7 @@ describe('demand recordDelivery', function () {
       controller: { my: true, pos: { findInRange: () => [] } },
       find: () => [],
     };
-    demand.recordDelivery('target1', 100, 20, 'W1N1');
+    demand.recordDelivery('target1', 100, 20, 'W1N1', 'h1');
     demand.run();
     const tasks = Memory.htm.colonies['W1N1'].tasks;
     const haulTask = tasks.find(t => t.name === 'spawnHauler');
@@ -50,7 +50,7 @@ describe('demand recordDelivery', function () {
 
   it('migrates legacy memory layout', function() {
     Memory.demand = { requesters: {}, runNextTick: false };
-    demand.recordDelivery('legacy', 5, 25, 'W1N1');
+    demand.recordDelivery('legacy', 5, 25, 'W1N1', 'h1');
     expect(Memory.demand.rooms).to.exist;
     expect(Memory.demand.rooms['W1N1']).to.exist;
   });


### PR DESCRIPTION
## Summary
- track energy requests and deliveries per room
- store aggregated demand and supply totals
- add deliverer stats and request logging
- clean creep HTM tasks on death
- document demand metrics
- update roadmap
- adjust tests for new demand interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845b167d7748327bbf5e84b1a2a1a55