### PR TITLE
Fix hauler demand calculations and spawn scaling

### DIFF
--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -32,18 +32,20 @@ its queue is empty.
   monitors controller containers and construction sites. When no creeps remain
   the queue is purged and a bootstrap worker is scheduled so the colony can
   recover.
-- **demand** – Tracks energy deliveries. When average rates fall below
-  acceptable thresholds the module queues an additional hauler for the affected
-  colony. Delivery statistics are stored per-room under `Memory.demand.rooms`
-  along with aggregate `totals` for outstanding demand and current delivery
-  supply. Each requester and deliverer tracks the last energy amount and time
-  for deliveries so average energy-per-tick rates can be calculated. These
-  averages are stored per-room and globally under `Memory.demand.globalTotals`
-  (`demandRate` and `supplyRate`). Early game miners and bootstrap workers
-  count as deliverers so the Hive can spawn haulers before dedicated carriers
-  exist. The module migrates legacy flat layouts automatically. It only runs
-  when flagged by a completed delivery but maintains these totals every tick so
-  other systems can react without recalculating.
+ - **demand** – Tracks energy deliveries. When the combined
+  `demandRate` for requesters exceeds the current `supplyRate` the Hive
+  automatically queues enough haulers to close the gap. Delivery statistics are
+  stored per-room under `Memory.demand.rooms` along with aggregate `totals`
+  for outstanding demand and current delivery supply. Each requester and
+  deliverer tracks the last energy amount and time for deliveries so average
+  energy-per-tick rates can be calculated. Early game miners and bootstrap
+  workers count as deliverers so the Hive can spawn haulers before dedicated
+  carriers exist. Stale entries are removed by comparing to `Game.creeps`
+  before demand is calculated, and outstanding energy requests are summed so
+  `totals.demand` reflects the true workload. Hauler spawns are throttled to
+  avoid spam. The module migrates legacy flat layouts automatically. It only
+  runs when flagged by a completed delivery but maintains these totals every
+  tick so other systems can react without recalculating.
   Modules can be added later for building, defense or expansion logic.
   The HiveMind also orders basic infrastructure:
   - Containers are planned as soon as the room is claimed (RCL1).

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -14,7 +14,11 @@ Haulers remain governed by the energy demand module.
   desired number of upgraders (four per container).
 - **Builders** – Construction sites are prioritised by type. Extensions,
   containers and roads request up to four builders per site (maximum eight).
-  Other sites spawn two builders each with the same overall cap.
+  Other sites spawn two builders each with the same overall cap. Builders keep
+  their assigned construction site until it is completed and remain near the
+  location while waiting for energy deliveries. When out of energy they either
+  request a hauler or fetch nearby drops before returning to the site, reducing
+  wandering.
 
 The module updates `Memory.roleEval.lastRun` so a fallback task can throttle
 itself when CPU is scarce.

--- a/manager.hivemind.demand.js
+++ b/manager.hivemind.demand.js
@@ -5,6 +5,9 @@ const spawnQueue = require('./manager.spawnQueue');
 const _ = require('lodash');
 
 const ENERGY_PER_TICK_THRESHOLD = 1; // Delivery rate below which more haulers are spawned
+const DEFAULT_HAULER_RATE = 5; // Fallback energy/tick value when no haulers exist
+const MAX_HAULERS_PER_ROOM = 4; // Safeguard against spamming hauler spawns
+const HAULER_SPAWN_COOLDOWN = 50; // Minimum ticks between hauler spawn attempts
 
 function initMemory() {
   if (!Memory.demand || !Memory.demand.rooms) {
@@ -193,6 +196,22 @@ const demandModule = {
   run() {
     initMemory();
 
+    // Remove entries for creeps that no longer exist so rates remain accurate
+    for (const roomName in Memory.demand.rooms) {
+      const mem = Memory.demand.rooms[roomName];
+      for (const name in mem.deliverers) {
+        if (!Memory.creeps[name]) delete mem.deliverers[name];
+      }
+      for (const id in mem.requesters) {
+        const obj = typeof Game.getObjectById === 'function'
+          ? Game.getObjectById(id)
+          : null;
+        if (!Memory.creeps[id] && !obj) {
+          delete mem.requesters[id];
+        }
+      }
+    }
+
     Memory.demand.globalTotals.demand = 0;
     Memory.demand.globalTotals.supply = 0;
     Memory.demand.globalTotals.demandRate = 0;
@@ -222,6 +241,11 @@ const demandModule = {
             }
           }
         }
+      }
+      for (const id in roomMem.requesters) {
+        const req = roomMem.requesters[id];
+        if (req.lastEnergyRequested) demandAmount += req.lastEnergyRequested;
+        else if (req.averageRequested) demandAmount += req.averageRequested;
       }
       roomMem.totals.demand = demandAmount;
       Memory.demand.globalTotals.demand += demandAmount;
@@ -265,13 +289,12 @@ const demandModule = {
       let demandRate = 0;
       for (const id in requesters) {
         const data = requesters[id];
-        const rate =
-          data.averageTickTime > 0
-            ? data.averageEnergy / data.averageTickTime
-            : 0;
+        const tickTime = data.averageTickTime || 0;
+        const energy = data.averageEnergy || 0;
+        const rate = tickTime > 0 ? energy / tickTime : 0;
         demandRate += rate;
         statsConsole.log(
-          `Demand ${id}: avg ${data.averageEnergy.toFixed(1)} energy / ${data.averageTickTime.toFixed(1)} ticks`,
+          `Demand ${id}: avg ${energy.toFixed(1)} energy / ${tickTime.toFixed(1)} ticks`,
           2,
         );
         if (rate < ENERGY_PER_TICK_THRESHOLD) {
@@ -330,22 +353,35 @@ const demandModule = {
         Game.creeps,
         c => c.memory.role === 'hauler' && c.room.name === roomName,
       ).length;
+      const minersAlive = _.filter(
+        Game.creeps,
+        c => c.memory.role === 'miner' && c.room.name === roomName,
+      ).length;
       const queuedHaulers = spawnQueue.queue.filter(
         q => q.room === roomName && q.memory.role === 'hauler',
       ).length;
       const currentAmount =
         haulersAlive + queuedHaulers + (existing ? existing.amount || 0 : 0);
-      let required = 1;
-      const minersAlive = _.filter(
-        Game.creeps,
-        c => c.memory.role === 'miner' && c.room.name === roomName,
-      ).length;
-      const queuedMiners = spawnQueue.queue.filter(
-        q => q.room === roomName && q.memory.role === 'miner',
-      ).length;
-      if (minersAlive + queuedMiners >= 2) required = 2;
-      const toQueue = Math.max(0, required - currentAmount);
-      if (toQueue > 0) {
+
+      const roomMem = Memory.demand.rooms[roomName];
+      const demandRate = roomMem.totals.demandRate;
+      const supplyRate = roomMem.totals.supplyRate;
+      const perHauler =
+        haulersAlive > 0
+          ? supplyRate / haulersAlive
+          : DEFAULT_HAULER_RATE;
+      let target = Math.min(
+        MAX_HAULERS_PER_ROOM,
+        Math.ceil(demandRate / Math.max(perHauler, ENERGY_PER_TICK_THRESHOLD)),
+      );
+      if (target === 0 && haulersAlive === 0 && minersAlive > 0) target = 1;
+      const toQueue = Math.max(0, target - currentAmount);
+
+      if (
+        toQueue > 0 &&
+        (roomMem.lastSpawnTick === undefined ||
+          Game.time - roomMem.lastSpawnTick >= HAULER_SPAWN_COOLDOWN)
+      ) {
         if (existing) existing.amount += toQueue;
         else
           htm.addColonyTask(
@@ -357,8 +393,13 @@ const demandModule = {
             toQueue,
             'spawnManager',
           );
-        statsConsole.log(`Energy demand high in ${roomName}: queued hauler`, 2);
+        roomMem.lastSpawnTick = Game.time;
+        statsConsole.log(
+          `Energy demand high in ${roomName}: queued ${toQueue} hauler(s)`,
+          2,
+        );
       }
+
       const room = Game.rooms[roomName];
       if (room) {
         const roles = require('./hive.roles');

--- a/test/builderAssignment.test.js
+++ b/test/builderAssignment.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const globals = require('./mocks/globals');
 
 const roleBuilder = require('../role.builder');
+const htm = require('../manager.htm');
 
 global.FIND_CONSTRUCTION_SITES = 1;
 global.FIND_MY_SPAWNS = 2;
@@ -43,6 +44,8 @@ describe('builder assignment', function () {
   beforeEach(function () {
     globals.resetGame();
     globals.resetMemory();
+    htm.init();
+    Memory.htm.creeps = {};
     const site = createSite('s1');
     Game.rooms['W1N1'] = {
       name: 'W1N1',

--- a/test/demandCleanup.test.js
+++ b/test/demandCleanup.test.js
@@ -1,0 +1,63 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const demand = require('../manager.hivemind.demand');
+const htm = require('../manager.htm');
+
+global.RESOURCE_ENERGY = 'energy';
+
+describe('demand cleanup of dead creeps', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory({ stats: { logs: [] } });
+    htm.init();
+    Memory.htm.colonies['W1N1'] = { tasks: [] };
+    Memory.creeps = { liveHauler: {} };
+
+    Memory.demand = {
+      rooms: {
+        W1N1: {
+          requesters: {
+            deadCreep: { deliveries: 1, averageEnergy: 50, averageTickTime: 10 },
+          },
+          deliverers: {
+            deadHauler: { deliveries: 1, averageEnergy: 50, averageTickTime: 10 },
+            liveHauler: { deliveries: 1, averageEnergy: 50, averageTickTime: 10 },
+          },
+          totals: { demand: 0, supply: 0, demandRate: 0, supplyRate: 0 },
+          runNextTick: true,
+        },
+      },
+      globalTotals: { demand: 0, supply: 0, demandRate: 0, supplyRate: 0 },
+    };
+
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true, pos: { findInRange: () => [] } },
+      find: () => [],
+    };
+    Game.getObjectById = () => null;
+    Game.creeps = {
+      liveHauler: { memory: { role: 'hauler' }, room: { name: 'W1N1' }, store: { [RESOURCE_ENERGY]: 0 } },
+    };
+  });
+
+  it('removes non-existent creeps from demand data', function () {
+    demand.run();
+    const roomMem = Memory.demand.rooms['W1N1'];
+    expect(roomMem.deliverers.deadHauler).to.be.undefined;
+    expect(roomMem.deliverers.liveHauler).to.exist;
+    expect(roomMem.requesters.deadCreep).to.be.undefined;
+  });
+
+  it('totals include outstanding requests', function () {
+    Memory.demand.rooms['W1N1'].requesters = {
+      s1: { lastEnergyRequested: 100, deliveries: 0, averageRequested: 100 },
+    };
+    Game.getObjectById = id => ({ id });
+    Memory.demand.rooms['W1N1'].runNextTick = true;
+    demand.run();
+    const roomMem = Memory.demand.rooms['W1N1'];
+    expect(roomMem.totals.demand).to.equal(100);
+  });
+});

--- a/test/demandFallback.test.js
+++ b/test/demandFallback.test.js
@@ -11,6 +11,8 @@ describe('demand fallback hauler spawn', function () {
     htm.init();
     Memory.htm.colonies['W1N1'] = { tasks: [] };
     demand.shouldRun();
+    Memory.creeps = {};
+    Game.getObjectById = id => ({ id });
   });
 
   it('queues hauler when miners exist but no haulers', function () {

--- a/test/demandRecord.test.js
+++ b/test/demandRecord.test.js
@@ -10,6 +10,8 @@ describe('demand recordDelivery', function () {
     const htm = require('../manager.htm');
     htm.init();
     Memory.htm.colonies['W1N1'] = { tasks: [] };
+    Memory.creeps = {};
+    Game.getObjectById = id => ({ id });
   });
 
   it('updates averages and flags next run', function () {

--- a/test/demandSpawnRate.test.js
+++ b/test/demandSpawnRate.test.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const demand = require('../manager.hivemind.demand');
+const htm = require('../manager.htm');
+
+global.RESOURCE_ENERGY = 'energy';
+
+describe('demand spawn scaling', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory({ stats: { logs: [] } });
+    htm.init();
+    Memory.htm.colonies['W1N1'] = { tasks: [] };
+    Memory.creeps = { h1: {} };
+    Game.getObjectById = id => ({ id });
+
+    Memory.demand = {
+      rooms: {
+        W1N1: {
+          requesters: {
+            s1: { deliveries: 1, averageEnergy: 100, averageTickTime: 5 },
+          },
+          deliverers: {
+            h1: { deliveries: 1, averageEnergy: 20, averageTickTime: 10 },
+          },
+          totals: { demand: 0, supply: 0, demandRate: 0, supplyRate: 0 },
+          runNextTick: true,
+        },
+      },
+      globalTotals: { demand: 0, supply: 0, demandRate: 0, supplyRate: 0 },
+    };
+
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true, pos: { findInRange: () => [] } },
+      find: () => [],
+    };
+    Game.creeps = {
+      h1: { memory: { role: 'hauler' }, room: { name: 'W1N1' }, store: { [RESOURCE_ENERGY]: 0 } },
+    };
+  });
+
+  it('queues additional haulers based on demand rate', function () {
+    demand.run();
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    const haulTask = tasks.find(t => t.name === 'spawnHauler');
+    expect(haulTask).to.exist;
+    expect(haulTask.amount).to.equal(3);
+  });
+});


### PR DESCRIPTION
## Summary
- clean up deliverer and requester entries using `Memory.creeps`
- include outstanding requests in demand totals
- guard against missing averages when logging demand rate
- document demand memory cleanup and builder idle behavior
- expand demand cleanup test for totals calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bd6ed444832799b1d8415c0483a3