### PR TITLE
Fix builder & upgrader energy behaviors

### DIFF
--- a/docs/roles.md
+++ b/docs/roles.md
@@ -13,14 +13,17 @@ Haulers remain governed by the energy demand module.
 - **Upgraders** – Containers two tiles from the controller dictate the
   desired number of upgraders (four per container). Upgraders stand at these
   containers or at a position two tiles from the controller, upgrading from
-  range. When no containers are present the system still spawns one upgrader so
-  progress never stalls.
+  range. Upgraders withdraw energy when adjacent to their container rather than
+  only when positioned directly on top. When no containers are present the
+  system still spawns one upgrader so progress never stalls.
 - **Builders** – Construction sites are prioritised by type. Extensions,
   containers and roads request up to four builders per site (maximum eight).
   Other sites spawn two builders each with the same overall cap. Builders keep
   their assigned construction site until it is completed and remain near the
   location while waiting for energy deliveries. While working they also collect
   dropped energy or withdraw from nearby containers to minimise idle time.
+  Builders start working as soon as some energy is carried so partially filled
+  workers no longer idle.
 
 The module updates `Memory.roleEval.lastRun` so a fallback task can throttle
 itself when CPU is scarce.

--- a/role.builder.js
+++ b/role.builder.js
@@ -71,6 +71,11 @@ const roleBuilder = {
       creep.memory.working = true;
       creep.say("⚡ build/repair");
     }
+    // Start working as soon as some energy is available to avoid idle creeps
+    if (!creep.memory.working && creep.store[RESOURCE_ENERGY] > 0) {
+      creep.memory.working = true;
+      creep.say("⚡ build/repair");
+    }
 
     if (creep.memory.working) {
       const roomMemory = Memory.rooms[creep.room.name];

--- a/role.upgrader.js
+++ b/role.upgrader.js
@@ -77,28 +77,29 @@ const roleUpgrader = {
     movementUtils.avoidSpawnArea(creep);
     if (creep.store[RESOURCE_ENERGY] === 0) {
       const pos = getUpgradePos(creep);
-      if (!creep.pos.isEqualTo || !creep.pos.isEqualTo(pos)) {
-        creep.travelTo(pos, { visualizePathStyle: { stroke: '#ffaa00' } });
-        return;
-      }
       const container = creep.memory.containerId
         ? Game.getObjectById(creep.memory.containerId)
         : null;
-      if (container && container.store[RESOURCE_ENERGY] > 0) {
+
+      // Withdraw if close enough, otherwise move toward the upgrade position
+      if (
+        container &&
+        container.store[RESOURCE_ENERGY] > 0 &&
+        creep.pos.getRangeTo(container) <= 1
+      ) {
         if (creep.withdraw(container, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
           creep.travelTo(container, { visualizePathStyle: { stroke: '#ffaa00' } });
         }
       } else {
-        requestEnergy(creep);
+        creep.travelTo(pos, { visualizePathStyle: { stroke: '#ffaa00' } });
+        if (!container || creep.pos.getRangeTo(container) > 1) {
+          requestEnergy(creep);
+        }
       }
       return;
     }
 
     const pos = getUpgradePos(creep);
-    if (!creep.pos.isEqualTo(pos)) {
-      creep.travelTo(pos, { visualizePathStyle: { stroke: '#ffaa00' } });
-      return;
-    }
     if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
       creep.travelTo(pos, { visualizePathStyle: { stroke: '#ffffff' } });
     }

--- a/test/builderWorking.test.js
+++ b/test/builderWorking.test.js
@@ -1,0 +1,66 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const htm = require('../manager.htm');
+const roleBuilder = require('../role.builder');
+
+global.FIND_CONSTRUCTION_SITES = 1;
+global.FIND_MY_SPAWNS = 2;
+global.STRUCTURE_CONTAINER = 'container';
+global.RESOURCE_ENERGY = 'energy';
+global.OK = 0;
+
+function createSite(id) {
+  return {
+    id,
+    progress: 0,
+    progressTotal: 100,
+    structureType: STRUCTURE_CONTAINER,
+    pos: { x: 1, y: 1, roomName: 'W1N1', lookFor: () => [] },
+  };
+}
+
+function createCreep(name) {
+  return {
+    name,
+    memory: { working: false },
+    room: Game.rooms['W1N1'],
+    store: { [RESOURCE_ENERGY]: 20, getFreeCapacity: () => 30 },
+    pos: {
+      x: 10,
+      y: 10,
+      roomName: 'W1N1',
+      getRangeTo: () => 1,
+      findClosestByRange: () => null,
+      findInRange: () => [],
+    },
+    travelTo: () => {},
+    build: () => OK,
+    upgradeController: () => OK,
+    say: () => {},
+  };
+}
+
+describe('builder working state', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    Memory.htm.creeps = {};
+    const site = createSite('s1');
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      find: type => (type === FIND_CONSTRUCTION_SITES ? [site] : []),
+      memory: { buildingQueue: [{ id: 's1', priority: 100 }] },
+      controller: {},
+    };
+    Game.getObjectById = () => site;
+    Memory.rooms = { W1N1: { buildingQueue: [{ id: 's1', priority: 100 }], siteAssignments: {} } };
+  });
+
+  it('begins building when partially filled with energy', function () {
+    const creep = createCreep('b1');
+    roleBuilder.run(creep);
+    expect(creep.memory.working).to.be.true;
+  });
+});

--- a/test/energyRequest.test.js
+++ b/test/energyRequest.test.js
@@ -38,9 +38,6 @@ describe('energy request tasks', function() {
   it('queues deliverEnergy when upgrader is empty', function() {
     const creep = createCreep('u1');
     roleUpgrader.run(creep);
-    // Simulate arriving at the idle position next tick
-    creep.pos.isEqualTo = () => true;
-    roleUpgrader.run(creep);
     const tasks = Memory.htm.creeps['u1'].tasks;
     expect(tasks[0].name).to.equal('deliverEnergy');
   });
@@ -58,8 +55,7 @@ describe('energy request tasks', function() {
     Game.getObjectById = id => container;
     const creep = createCreep('u2');
     creep.withdraw = () => OK;
-    roleUpgrader.run(creep);
-    creep.pos.isEqualTo = () => true;
+    creep.pos.getRangeTo = () => 1;
     roleUpgrader.run(creep);
     expect(Memory.htm.creeps['u2']).to.be.undefined;
   });


### PR DESCRIPTION
## Summary
- ensure builders resume work once they have any energy
- allow upgraders to withdraw while adjacent to containers
- document role tweaks in `docs/roles.md`
- add tests for builder working state and updated upgrader logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845e21966ac832790205586f67b291b