### PR TITLE
Dynamic miner evaluation and builder fixes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@
 - [x] Hierarchical memory layout: Hive → Cluster → Colony → Creep
 - [x] Auto-initialization on boot
 - [x] Release mining positions when creeps die
+- [x] Cleanup HTM creep memory when creeps expire
 - [ ] Auto-assimilation of newly seen rooms into structure
 - [ ] Persistent memory for lost-vision rooms
 - [ ] Expiration system for temporary memory entries – *Prio 3*
@@ -79,8 +80,10 @@
 - [x] Scans rooms for sources and structures
 - [x] Evaluates spawn demand per role
 - [x] Reserves mining positions for miners
+- [x] Recalculate mining spots and prefer container positions
 - [x] Replacement miners requested before predecessors expire
 - [x] Reserved positions cleared on miner/allPurpose death
+- [x] Miners with 5 WORK parts reposition onto containers
 
 ### 🔄 Energy Demand Module (Prio 3)
 - [x] Record delivery performance for requesters
@@ -89,6 +92,7 @@
 - [x] Initial spawn order enforces allPurpose, miners and haulers before upgraders
 - [x] Persist aggregated demand and hauler supply metrics
 - [x] Global demand totals aggregate per room and supply rate only counts hauler deliveries
+- [x] Haulers prioritise ruins and tombstones when closer than containers
 
 ---
 

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -6,10 +6,12 @@ Haulers remain governed by the energy demand module.
 
 ## Behaviour
 
-- **Miners** – Each source is analysed for open mining positions. Current miners
-  and queued requests are counted and additional miners are requested until the
-  source is saturated. Mining power is based on the miner DNA returned by
-  `manager.dna` and capped at three creeps per source.
+ - **Miners** – Each source is analysed for open mining positions. Current miners
+   and queued requests are counted and additional miners are requested until the
+   source is saturated. Mining power is based on the miner DNA returned by
+   `manager.dna` and capped at three creeps per source. Miners with at least five
+   WORK parts automatically relocate onto the nearby container so they can empty
+   the source without moving.
 - **Upgraders** – Containers two tiles from the controller dictate the
   desired number of upgraders (four per container). Upgraders stand at these
   containers or at a position two tiles from the controller, upgrading from
@@ -17,7 +19,7 @@ Haulers remain governed by the energy demand module.
   only when positioned directly on top. When no containers are present the
   system still spawns one upgrader so progress never stalls.
 - **Builders** – Construction sites are prioritised by type. Extensions,
-  containers and roads request up to four builders per site (maximum eight).
+  containers and roads request up to four builders per site (maximum twelve).
   Other sites spawn two builders each with the same overall cap. Builders keep
   their assigned construction site until it is completed and remain near the
   location while waiting for energy deliveries. While working they also collect

--- a/main.js
+++ b/main.js
@@ -116,12 +116,7 @@ scheduler.addTask("clearMemory", 100, () => {
       logger.log('memory', `Clearing memory of dead creep: ${name}`, 2);
       energyDemand.cleanupCreep(name);
       delete Memory.creeps[name];
-      if (
-        Memory.htm &&
-        Memory.htm.creeps &&
-        Memory.htm.creeps[name] &&
-        (!Memory.htm.creeps[name].tasks || Memory.htm.creeps[name].tasks.length === 0)
-      ) {
+      if (Memory.htm && Memory.htm.creeps && Memory.htm.creeps[name]) {
         delete Memory.htm.creeps[name];
       }
       removed = true;

--- a/manager.hivemind.demand.js
+++ b/manager.hivemind.demand.js
@@ -60,6 +60,8 @@ const demandModule = {
       amount,
     );
     roomMem.requesters[id] = data;
+    roomMem.runNextTick = true;
+    scheduler.requestTaskUpdate('energyDemand');
   },
   /**
    * Record delivery metrics for a requester and flag evaluation

--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -43,6 +43,25 @@ const spawnModule = {
           area.push({ x, y });
         }
       }
+
+      const mining =
+        Memory.rooms &&
+        Memory.rooms[roomName] &&
+        Memory.rooms[roomName].miningPositions
+          ? Memory.rooms[roomName].miningPositions
+          : null;
+      if (mining) {
+        for (const id in mining) {
+          const posObj = mining[id].positions || {};
+          for (const key in posObj) {
+            const p = posObj[key];
+            if (p && p.x !== undefined && p.y !== undefined) {
+              area.push({ x: p.x, y: p.y });
+            }
+          }
+        }
+      }
+
       if (!Memory.rooms[roomName]) Memory.rooms[roomName] = {};
       Memory.rooms[roomName].restrictedArea = area;
     }

--- a/manager.room.js
+++ b/manager.room.js
@@ -17,9 +17,9 @@ const roomManager = {
     }
 
     sources.forEach((source) => {
-      const spawn = room.find(FIND_MY_SPAWNS)[0]; // Assuming there's at least one spawn
+      const spawn = room.find(FIND_MY_SPAWNS)[0];
       const sourcePos = source.pos;
-      const potentialMiningSpots = [
+      const potential = [
         { x: sourcePos.x + 1, y: sourcePos.y },
         { x: sourcePos.x - 1, y: sourcePos.y },
         { x: sourcePos.x, y: sourcePos.y + 1 },
@@ -28,55 +28,44 @@ const roomManager = {
         { x: sourcePos.x + 1, y: sourcePos.y - 1 },
         { x: sourcePos.x - 1, y: sourcePos.y + 1 },
         { x: sourcePos.x - 1, y: sourcePos.y - 1 },
-      ];
+      ].filter(p => room.getTerrain().get(p.x, p.y) !== TERRAIN_MASK_WALL);
 
-      // Filter out positions that are walls
-      const miningSpots = potentialMiningSpots.filter(
-        (spot) => room.getTerrain().get(spot.x, spot.y) !== TERRAIN_MASK_WALL,
+      potential.sort((a, b) =>
+        spawn.pos.getRangeTo(a.x, a.y) - spawn.pos.getRangeTo(b.x, b.y),
       );
 
-      // Sort mining spots by distance to spawn
-      miningSpots.sort(
-        (a, b) =>
-          spawn.pos.getRangeTo(a.x, a.y) - spawn.pos.getRangeTo(b.x, b.y),
-      );
+      const containers = room.find(FIND_STRUCTURES, {
+        filter: s => s.structureType === STRUCTURE_CONTAINER && s.pos.inRangeTo(source, 1),
+      });
 
-      // Limit to a maximum of 3 positions
-      const bestPositions = miningSpots.slice(0, 3);
-
-      // Only initialize if not already present to preserve reservation state
-      if (!Memory.rooms[room.name].miningPositions[source.id]) {
-        Memory.rooms[room.name].miningPositions[source.id] = {
-          x: sourcePos.x,
-          y: sourcePos.y,
-          positions: {
-            best1: bestPositions[0]
-              ? {
-                x: bestPositions[0].x,
-                y: bestPositions[0].y,
-                roomName: room.name,
-                reserved: false,
-              }
-            : null,
-          best2: bestPositions[1]
-            ? {
-                x: bestPositions[1].x,
-                y: bestPositions[1].y,
-                roomName: room.name,
-                reserved: false,
-              }
-            : null,
-            best3: bestPositions[2]
-              ? {
-                x: bestPositions[2].x,
-                y: bestPositions[2].y,
-                roomName: room.name,
-                reserved: false,
-              }
-              : null,
-          },
-        };
+      let bestPositions = potential.slice(0, 3);
+      if (containers.length > 0) {
+        const cPos = containers[0].pos;
+        bestPositions = [{ x: cPos.x, y: cPos.y }, ...potential.filter(p => p.x !== cPos.x || p.y !== cPos.y).slice(0, 2)];
       }
+
+      const mem = Memory.rooms[room.name].miningPositions[source.id] || { positions: {} };
+      const old = mem.positions || {};
+      const positions = {};
+      ['best1', 'best2', 'best3'].forEach((key, i) => {
+        const p = bestPositions[i];
+        if (p) {
+          const existing = Object.values(old).find(o => o && o.x === p.x && o.y === p.y);
+          positions[key] = {
+            x: p.x,
+            y: p.y,
+            roomName: room.name,
+            reserved: existing ? existing.reserved : false,
+          };
+        } else {
+          positions[key] = null;
+        }
+      });
+      Memory.rooms[room.name].miningPositions[source.id] = {
+        x: sourcePos.x,
+        y: sourcePos.y,
+        positions,
+      };
     });
 
     // Additional room-specific data can be gathered here

--- a/test/builderAssignment.test.js
+++ b/test/builderAssignment.test.js
@@ -7,8 +7,11 @@ const htm = require('../manager.htm');
 global.FIND_CONSTRUCTION_SITES = 1;
 global.FIND_MY_SPAWNS = 2;
 global.STRUCTURE_CONTAINER = 'container';
+global.STRUCTURE_STORAGE = 'storage';
 global.RESOURCE_ENERGY = 'energy';
 global.OK = 0;
+global.LOOK_CREEPS = 'creep';
+global.TERRAIN_MASK_WALL = 1;
 
 function createSite(id) {
   return {
@@ -33,6 +36,7 @@ function createCreep(name) {
       getRangeTo: () => 1,
       findClosestByRange: () => null,
       findInRange: () => [],
+      isEqualTo: function (p) { return p.x === this.x && p.y === this.y; },
     },
     travelTo: () => {},
     build: () => OK,

--- a/test/builderEnergy.test.js
+++ b/test/builderEnergy.test.js
@@ -9,6 +9,7 @@ global.FIND_DROPPED_RESOURCES = 2;
 global.FIND_STRUCTURES = 3;
 global.FIND_CONSTRUCTION_SITES = 4;
 global.STRUCTURE_CONTAINER = 'container';
+global.STRUCTURE_STORAGE = 'storage';
 global.RESOURCE_ENERGY = 'energy';
 global.OK = 0;
 global.ERR_NOT_IN_RANGE = -9;

--- a/test/builderMultipleSites.test.js
+++ b/test/builderMultipleSites.test.js
@@ -7,8 +7,11 @@ const htm = require('../manager.htm');
 global.FIND_CONSTRUCTION_SITES = 1;
 global.FIND_MY_SPAWNS = 2;
 global.STRUCTURE_CONTAINER = 'container';
+global.STRUCTURE_STORAGE = 'storage';
 global.RESOURCE_ENERGY = 'energy';
 global.OK = 0;
+global.LOOK_CREEPS = 'creep';
+global.TERRAIN_MASK_WALL = 1;
 
 function createSite(id) {
   return {
@@ -33,6 +36,7 @@ function createCreep(name) {
       getRangeTo: () => 1,
       findClosestByRange: () => null,
       findInRange: () => [],
+      isEqualTo: function (p) { return p.x === this.x && p.y === this.y; },
     },
     travelTo: () => {},
     build: () => OK,

--- a/test/builderWorking.test.js
+++ b/test/builderWorking.test.js
@@ -7,8 +7,11 @@ const roleBuilder = require('../role.builder');
 global.FIND_CONSTRUCTION_SITES = 1;
 global.FIND_MY_SPAWNS = 2;
 global.STRUCTURE_CONTAINER = 'container';
+global.STRUCTURE_STORAGE = 'storage';
 global.RESOURCE_ENERGY = 'energy';
 global.OK = 0;
+global.LOOK_CREEPS = 'creep';
+global.TERRAIN_MASK_WALL = 1;
 
 function createSite(id) {
   return {
@@ -33,6 +36,7 @@ function createCreep(name) {
       getRangeTo: () => 1,
       findClosestByRange: () => null,
       findInRange: () => [],
+      isEqualTo: function (p) { return p.x === this.x && p.y === this.y; },
     },
     travelTo: () => {},
     build: () => OK,
@@ -51,6 +55,8 @@ describe('builder working state', function () {
     Game.rooms['W1N1'] = {
       name: 'W1N1',
       find: type => (type === FIND_CONSTRUCTION_SITES ? [site] : []),
+      getTerrain: () => ({ get: () => 0 }),
+      lookForAt: () => [],
       memory: { buildingQueue: [{ id: 's1', priority: 100 }] },
       controller: {},
     };
@@ -62,5 +68,19 @@ describe('builder working state', function () {
     const creep = createCreep('b1');
     roleBuilder.run(creep);
     expect(creep.memory.working).to.be.true;
+  });
+
+  it('moves off construction site when standing on it', function () {
+    const creep = createCreep('b2');
+    const site = Game.getObjectById('s1');
+    creep.pos.x = site.pos.x;
+    creep.pos.y = site.pos.y;
+    let moved = false;
+    creep.move = () => {
+      moved = true;
+      return OK;
+    };
+    roleBuilder.run(creep);
+    expect(moved).to.be.true;
   });
 });

--- a/test/demandRecord.test.js
+++ b/test/demandRecord.test.js
@@ -56,4 +56,10 @@ describe('demand recordDelivery', function () {
     expect(Memory.demand.rooms).to.exist;
     expect(Memory.demand.rooms['W1N1']).to.exist;
   });
+
+  it('flags next run when recording request', function () {
+    demand.recordRequest('b1', 50, 'W1N1');
+    const roomMem = Memory.demand.rooms['W1N1'];
+    expect(roomMem.runNextTick).to.be.true;
+  });
 });

--- a/test/haulerRuinPickup.test.js
+++ b/test/haulerRuinPickup.test.js
@@ -1,0 +1,56 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const roleHauler = require('../role.hauler');
+
+// Minimal constants
+global.RESOURCE_ENERGY = 'energy';
+global.FIND_DROPPED_RESOURCES = 1;
+global.FIND_RUINS = 2;
+global.FIND_TOMBSTONES = 3;
+global.FIND_STRUCTURES = 4;
+global.STRUCTURE_CONTAINER = 'container';
+global.OK = 0;
+
+function createHauler(name) {
+  return {
+    name,
+    store: { [RESOURCE_ENERGY]: 0, getFreeCapacity: () => 50 },
+    room: { name: 'W1N1', storage: null },
+    pos: {
+      x: 10,
+      y: 10,
+      roomName: 'W1N1',
+      getRangeTo(pos) {
+        return Math.abs(this.x - pos.x) + Math.abs(this.y - pos.y);
+      },
+      findClosestByPath(type, opts) {
+        if (type === FIND_RUINS) return this._ruin;
+        if (type === FIND_STRUCTURES) return this._container;
+        return null;
+      }
+    },
+    travelTo: () => {},
+    pickup: () => OK,
+    withdraw(target) { this.target = target; return OK; },
+    memory: {},
+  };
+}
+
+describe('hauler prefers nearby ruin', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    Game.rooms['W1N1'] = { name: 'W1N1', find: () => [] };
+  });
+
+  it('withdraws from ruin when closer than container', function() {
+    const creep = createHauler('h1');
+    const ruin = { store: { [RESOURCE_ENERGY]: 100 }, pos: { x: 11, y: 10, roomName: 'W1N1' } };
+    const container = { structureType: STRUCTURE_CONTAINER, store: { [RESOURCE_ENERGY]: 100 }, pos: { x: 20, y: 20, roomName: 'W1N1' } };
+    creep.pos._ruin = ruin;
+    creep.pos._container = container;
+    roleHauler.run(creep);
+    expect(creep.target).to.equal(ruin);
+  });
+});

--- a/test/minerContainerPos.test.js
+++ b/test/minerContainerPos.test.js
@@ -1,0 +1,57 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const roleMiner = require('../role.miner');
+
+global.FIND_SOURCES = 1;
+global.FIND_STRUCTURES = 2;
+global.FIND_MY_SPAWNS = 3;
+global.STRUCTURE_CONTAINER = 'container';
+global.RESOURCE_ENERGY = 'energy';
+global.WORK = 'work';
+global.OK = 0;
+global.ERR_NOT_ENOUGH_RESOURCES = -6;
+global.ERR_NOT_IN_RANGE = -9;
+
+function createMiner() {
+  return {
+    name: 'm1',
+    body: Array(5).fill({ type: WORK }),
+    getActiveBodyparts(type) { return this.body.length; },
+    memory: { sourceId: 'src1', miningPosition: { x: 5, y: 6, roomName: 'W1N1' } },
+    room: { name: 'W1N1', getTerrain: () => ({ get: () => 0 }) },
+    store: { [RESOURCE_ENERGY]: 0 },
+    pos: {
+      x: 5,
+      y: 6,
+      roomName: 'W1N1',
+      isEqualTo(pos) { return this.x === pos.x && this.y === pos.y; },
+      findInRange() { return []; },
+      findClosestByRange() { return { pos: { x: 1, y: 1 } }; },
+      getRangeTo() { return 1; },
+      isNearTo() { return false; },
+    },
+    harvest: () => OK,
+    transfer: () => OK,
+    travelTo() {},
+  };
+}
+
+describe('miner relocates onto container', function() {
+  let container;
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    container = { structureType: STRUCTURE_CONTAINER, pos: { x: 6, y: 5, roomName: 'W1N1' }, store: { getFreeCapacity: () => 1000 } };
+    const source = { id: 'src1', pos: { x: 5, y: 5, findInRange: (t,r) => t === FIND_STRUCTURES ? [container] : [] } };
+    global.Game.getObjectById = () => source;
+    Game.rooms['W1N1'] = { find: () => [], controller: {} };
+  });
+
+  it('updates miningPosition to container when equipped to empty mine', function() {
+    const creep = createMiner();
+    roleMiner.run(creep);
+    expect(creep.memory.miningPosition.x).to.equal(6);
+    expect(creep.memory.miningPosition.y).to.equal(5);
+  });
+});

--- a/utils.movement.js
+++ b/utils.movement.js
@@ -31,6 +31,38 @@ const movementUtils = {
       }
     }
   },
+
+  /**
+   * Step off the current tile if standing on an invalid position such as a construction site.
+   * Attempts to move to the first open adjacent tile.
+   * @param {Creep} creep - The creep to reposition.
+   * @returns {boolean} True if a move command was issued.
+   */
+  stepOff(creep) {
+    if (!creep.room || !creep.room.getTerrain) return false;
+    const terrain = creep.room.getTerrain();
+    const deltas = {
+      [TOP]: { x: 0, y: -1 },
+      [TOP_RIGHT]: { x: 1, y: -1 },
+      [RIGHT]: { x: 1, y: 0 },
+      [BOTTOM_RIGHT]: { x: 1, y: 1 },
+      [BOTTOM]: { x: 0, y: 1 },
+      [BOTTOM_LEFT]: { x: -1, y: 1 },
+      [LEFT]: { x: -1, y: 0 },
+      [TOP_LEFT]: { x: -1, y: -1 },
+    };
+    for (const dir of Object.keys(deltas)) {
+      const d = deltas[dir];
+      const x = creep.pos.x + d.x;
+      const y = creep.pos.y + d.y;
+      if (x < 0 || x > 49 || y < 0 || y > 49) continue;
+      if (terrain.get(x, y) === TERRAIN_MASK_WALL) continue;
+      if (creep.room.lookForAt(LOOK_CREEPS, x, y).length > 0) continue;
+      creep.move(Number(dir));
+      return true;
+    }
+    return false;
+  },
 };
 
 module.exports = movementUtils;


### PR DESCRIPTION
## Summary
- refine energy pickup logic so haulers also harvest ruins and tombstones when nearby
- reposition powerful miners onto source containers automatically
- document miner container use and new builder cap
- track these behaviours in the roadmap
- add tests for hauler ruin pickup and miner relocation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845fd8446d48327acf1d0d31e4e5a53