### PR TITLE
Fix container placement, drop spawn buffer

### DIFF
--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -54,7 +54,7 @@ its queue is empty.
   - Containers are planned as soon as the room is claimed (RCL1).
   - Extensions begin construction when the controller reaches RCL2.
   - Source containers are prioritized before extensions, followed by controller
-    and buffer containers.
+    containers.
   - Mining positions are freed when miners approach expiry so replacements
     can claim the same spot. Any leftover reservations are cleared when
     miners or allPurpose creeps die.

--- a/manager.building.js
+++ b/manager.building.js
@@ -96,7 +96,8 @@ const buildingManager = {
 
     if (room.controller.level >= 1) {
       this.buildControllerContainers(room);
-      this.buildBufferContainer(room);
+      // Buffer container near the spawn is no longer required
+      // this.buildBufferContainer(room);
     }
   },
 

--- a/manager.room.js
+++ b/manager.room.js
@@ -30,6 +30,20 @@ const roomManager = {
         { x: sourcePos.x - 1, y: sourcePos.y - 1 },
       ].filter(p => room.getTerrain().get(p.x, p.y) !== TERRAIN_MASK_WALL);
 
+      // Determine container spot along the path to the spawn
+      let pathPosition = null;
+      if (spawn) {
+        const result = PathFinder.search(
+          spawn.pos,
+          { pos: sourcePos, range: 1 },
+          { swampCost: 2, plainCost: 2, ignoreCreeps: true },
+        );
+        if (result.path && result.path.length > 0) {
+          const step = result.path[result.path.length - 1];
+          pathPosition = { x: step.x, y: step.y };
+        }
+      }
+
       potential.sort((a, b) =>
         spawn.pos.getRangeTo(a.x, a.y) - spawn.pos.getRangeTo(b.x, b.y),
       );
@@ -42,6 +56,8 @@ const roomManager = {
       if (containers.length > 0) {
         const cPos = containers[0].pos;
         bestPositions = [{ x: cPos.x, y: cPos.y }, ...potential.filter(p => p.x !== cPos.x || p.y !== cPos.y).slice(0, 2)];
+      } else if (pathPosition) {
+        bestPositions = [pathPosition, ...potential.filter(p => p.x !== pathPosition.x || p.y !== pathPosition.y).slice(0, 2)];
       }
 
       const mem = Memory.rooms[room.name].miningPositions[source.id] || { positions: {} };

--- a/test/roomScanContainer.test.js
+++ b/test/roomScanContainer.test.js
@@ -1,0 +1,61 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const roomManager = require('../manager.room');
+
+// Constants required by roomManager
+global.FIND_SOURCES = 1;
+global.FIND_MY_SPAWNS = 2;
+global.FIND_STRUCTURES = 3;
+global.TERRAIN_MASK_WALL = 1;
+
+global.PathFinder = {
+  search(start, goal) {
+    return { path: [{ x: 11, y: 10 }], incomplete: false };
+  },
+};
+
+function getRangeTo(x1, y1, x2, y2) {
+  const dx = x1 - x2;
+  const dy = y1 - y2;
+  return Math.max(Math.abs(dx), Math.abs(dy));
+}
+
+describe('roomManager.scanRoom container placement', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    global.FIND_MY_SPAWNS = 2;
+    global.FIND_SOURCES = 1;
+    global.FIND_STRUCTURES = 3;
+    global.TERRAIN_MASK_WALL = 1;
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find(type) {
+        if (type === FIND_SOURCES) {
+          return [{ id: 's1', pos: { x: 10, y: 10 } }];
+        }
+        if (type === FIND_MY_SPAWNS) {
+          return [{ pos: { x: 25, y: 25, getRangeTo(targetX, targetY) {
+            if (typeof targetX === 'object') {
+              return getRangeTo(this.x, this.y, targetX.x, targetX.y);
+            }
+            return getRangeTo(this.x, this.y, targetX, targetY);
+          } } }];
+        }
+        if (type === FIND_STRUCTURES) return [];
+        return [];
+      },
+      getTerrain() {
+        return { get() { return 0; } };
+      },
+    };
+  });
+
+  it('stores path-based container position as best1', function() {
+    roomManager.scanRoom(Game.rooms['W1N1']);
+    const pos = Memory.rooms.W1N1.miningPositions.s1.positions.best1;
+    expect(pos).to.deep.equal({ x: 11, y: 10, roomName: 'W1N1', reserved: false });
+  });
+});


### PR DESCRIPTION
## Summary
- place source containers using path to spawn
- remove obsolete buffer container construction
- document container order without buffer sites
- test room scan container placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460c63a3648327ac6430b42ce12454