### PR TITLE
Fix container placement, drop spawn buffer

### DIFF
--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -54,7 +54,7 @@ its queue is empty.
   - Containers are planned as soon as the room is claimed (RCL1).
   - Extensions begin construction when the controller reaches RCL2.
   - Source containers are prioritized before extensions, followed by controller
-    and buffer containers.
+    containers.
   - Mining positions are freed when miners approach expiry so replacements
     can claim the same spot. Any leftover reservations are cleared when
     miners or allPurpose creeps die.

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -18,14 +18,14 @@ Haulers remain governed by the energy demand module.
   range. Upgraders withdraw energy when adjacent to their container rather than
   only when positioned directly on top. When no containers are present the
   system still spawns one upgrader so progress never stalls.
-- **Builders** – Construction sites are prioritised by type. Extensions,
+ - **Builders** – Construction sites are prioritised by type. Extensions,
   containers and roads request up to four builders per site (maximum twelve).
-  Other sites spawn two builders each with the same overall cap. Builders keep
-  their assigned construction site until it is completed and remain near the
-  location while waiting for energy deliveries. While working they also collect
-  dropped energy or withdraw from nearby containers to minimise idle time.
-  Builders start working as soon as some energy is carried so partially filled
-  workers no longer idle.
+  Other sites spawn two builders each with the same overall cap. Builders claim
+  a site as their **main task** and store this ID in memory so they resume
+  building after fetching energy. Energy pickup or delivery requests are tracked
+  as a sub-task but never overwrite the build assignment. Builders start working
+  as soon as some energy is carried so partially filled workers no longer idle.
+  At least two haulers must exist before additional builders are spawned.
 
 The module updates `Memory.roleEval.lastRun` so a fallback task can throttle
 itself when CPU is scarce.

--- a/hive.roles.js
+++ b/hive.roles.js
@@ -113,6 +113,16 @@ const roles = {
 
     // --- Builder calculation ---
     const sites = room.find(FIND_CONSTRUCTION_SITES);
+    const haulersAlive = _.filter(
+      Game.creeps,
+      c => c.memory.role === 'hauler' && c.room.name === roomName,
+    ).length;
+    const queuedHaulers = spawnQueue.queue.filter(
+      q => q.memory.role === 'hauler' && q.room === roomName,
+    ).length;
+    const haulerTask = tasks.find(t => t.name === 'spawnHauler' && t.manager === 'spawnManager');
+    const haulerTaskAmount = haulerTask ? haulerTask.amount || 0 : 0;
+    const totalHaulers = haulersAlive + queuedHaulers + haulerTaskAmount;
     const important = sites.filter(
       s =>
         s.structureType === STRUCTURE_EXTENSION ||
@@ -123,6 +133,7 @@ const roles = {
     let desiredBuilders = 0;
     if (important.length > 0) desiredBuilders = Math.min(12, important.length * 4);
     else desiredBuilders = Math.min(12, general * 2);
+    if (totalHaulers < 2) desiredBuilders = 0;
     const liveBuilders = _.filter(
       Game.creeps,
       c => c.memory.role === 'builder' && c.room.name === roomName,

--- a/manager.building.js
+++ b/manager.building.js
@@ -96,7 +96,8 @@ const buildingManager = {
 
     if (room.controller.level >= 1) {
       this.buildControllerContainers(room);
-      this.buildBufferContainer(room);
+      // Buffer container near the spawn is no longer required
+      // this.buildBufferContainer(room);
     }
   },
 

--- a/manager.room.js
+++ b/manager.room.js
@@ -30,6 +30,20 @@ const roomManager = {
         { x: sourcePos.x - 1, y: sourcePos.y - 1 },
       ].filter(p => room.getTerrain().get(p.x, p.y) !== TERRAIN_MASK_WALL);
 
+      // Determine container spot along the path to the spawn
+      let pathPosition = null;
+      if (spawn) {
+        const result = PathFinder.search(
+          spawn.pos,
+          { pos: sourcePos, range: 1 },
+          { swampCost: 2, plainCost: 2, ignoreCreeps: true },
+        );
+        if (result.path && result.path.length > 0) {
+          const step = result.path[result.path.length - 1];
+          pathPosition = { x: step.x, y: step.y };
+        }
+      }
+
       potential.sort((a, b) =>
         spawn.pos.getRangeTo(a.x, a.y) - spawn.pos.getRangeTo(b.x, b.y),
       );
@@ -42,6 +56,8 @@ const roomManager = {
       if (containers.length > 0) {
         const cPos = containers[0].pos;
         bestPositions = [{ x: cPos.x, y: cPos.y }, ...potential.filter(p => p.x !== cPos.x || p.y !== cPos.y).slice(0, 2)];
+      } else if (pathPosition) {
+        bestPositions = [pathPosition, ...potential.filter(p => p.x !== pathPosition.x || p.y !== pathPosition.y).slice(0, 2)];
       }
 
       const mem = Memory.rooms[room.name].miningPositions[source.id] || { positions: {} };

--- a/test/avoidSpawnAreaMiner.test.js
+++ b/test/avoidSpawnAreaMiner.test.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const movementUtils = require('../utils.movement');
+
+global.FIND_MY_SPAWNS = 1;
+
+function createCreep(spawn) {
+  return {
+    memory: { role: 'miner' },
+    room: { name: 'W1N1' },
+    pos: {
+      x: 10,
+      y: 10,
+      roomName: 'W1N1',
+      findClosestByRange(type) {
+        if (type === FIND_MY_SPAWNS) return spawn;
+        return null;
+      },
+      isNearTo() { return false; },
+      getRangeTo(target) {
+        const dx = this.x - target.pos.x;
+        const dy = this.y - target.pos.y;
+        return Math.max(Math.abs(dx), Math.abs(dy));
+      },
+    },
+    travelTo() { moved = true; },
+  };
+}
+
+describe('avoidSpawnArea skips miners', function() {
+  let spawn;
+  let moved;
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawn = { pos: { x: 25, y: 25 } };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      find(type) { if (type === FIND_MY_SPAWNS) return [spawn]; return []; },
+    };
+    Memory.rooms = { W1N1: { restrictedArea: [{ x: 10, y: 10 }] } };
+    moved = false;
+  });
+
+  it('does not move miner off restricted tile', function() {
+    const creep = createCreep(spawn);
+    movementUtils.avoidSpawnArea(creep);
+    expect(moved).to.be.false;
+  });
+});

--- a/test/builderTaskMemory.test.js
+++ b/test/builderTaskMemory.test.js
@@ -1,0 +1,53 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const htm = require('../manager.htm');
+const roleBuilder = require('../role.builder');
+
+global.FIND_MY_SPAWNS = 1;
+global.FIND_CONSTRUCTION_SITES = 2;
+global.STRUCTURE_CONTAINER = 'container';
+global.STRUCTURE_STORAGE = 'storage';
+global.RESOURCE_ENERGY = 'energy';
+global.OK = 0;
+
+describe('builder task memory', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    const site = { id: 's1', pos: { x: 1, y: 1, roomName: 'W1N1', lookFor: () => [] } };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      find: type => (type === FIND_CONSTRUCTION_SITES ? [site] : []),
+      memory: { buildingQueue: [{ id: 's1', priority: 100 }] },
+      controller: {},
+    };
+    Game.getObjectById = id => site;
+    Memory.rooms = { W1N1: { buildingQueue: [{ id: 's1', priority: 100 }], siteAssignments: {} } };
+  });
+
+  it('retains build task after requesting energy', function () {
+    const creep = {
+      name: 'b1',
+      room: Game.rooms['W1N1'],
+      store: { [RESOURCE_ENERGY]: 0, getFreeCapacity: () => 50 },
+      pos: {
+        x: 10,
+        y: 10,
+        roomName: 'W1N1',
+        getRangeTo: () => 1,
+        findInRange: () => [],
+      },
+      travelTo: () => {},
+      build: () => OK,
+      memory: {},
+    };
+    roleBuilder.run(creep);
+    expect(creep.memory.mainTask).to.deep.equal({ type: 'build', id: 's1' });
+    const tasks = Memory.htm.creeps['b1'].tasks;
+    const names = tasks.map(t => t.name);
+    expect(names).to.include('deliverEnergy');
+  });
+});
+

--- a/test/roomScanContainer.test.js
+++ b/test/roomScanContainer.test.js
@@ -1,0 +1,61 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const roomManager = require('../manager.room');
+
+// Constants required by roomManager
+global.FIND_SOURCES = 1;
+global.FIND_MY_SPAWNS = 2;
+global.FIND_STRUCTURES = 3;
+global.TERRAIN_MASK_WALL = 1;
+
+global.PathFinder = {
+  search(start, goal) {
+    return { path: [{ x: 11, y: 10 }], incomplete: false };
+  },
+};
+
+function getRangeTo(x1, y1, x2, y2) {
+  const dx = x1 - x2;
+  const dy = y1 - y2;
+  return Math.max(Math.abs(dx), Math.abs(dy));
+}
+
+describe('roomManager.scanRoom container placement', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    global.FIND_MY_SPAWNS = 2;
+    global.FIND_SOURCES = 1;
+    global.FIND_STRUCTURES = 3;
+    global.TERRAIN_MASK_WALL = 1;
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find(type) {
+        if (type === FIND_SOURCES) {
+          return [{ id: 's1', pos: { x: 10, y: 10 } }];
+        }
+        if (type === FIND_MY_SPAWNS) {
+          return [{ pos: { x: 25, y: 25, getRangeTo(targetX, targetY) {
+            if (typeof targetX === 'object') {
+              return getRangeTo(this.x, this.y, targetX.x, targetX.y);
+            }
+            return getRangeTo(this.x, this.y, targetX, targetY);
+          } } }];
+        }
+        if (type === FIND_STRUCTURES) return [];
+        return [];
+      },
+      getTerrain() {
+        return { get() { return 0; } };
+      },
+    };
+  });
+
+  it('stores path-based container position as best1', function() {
+    roomManager.scanRoom(Game.rooms['W1N1']);
+    const pos = Memory.rooms.W1N1.miningPositions.s1.positions.best1;
+    expect(pos).to.deep.equal({ x: 11, y: 10, roomName: 'W1N1', reserved: false });
+  });
+});

--- a/utils.movement.js
+++ b/utils.movement.js
@@ -8,8 +8,11 @@ const movementUtils = {
     const spawn = creep.pos.findClosestByRange(FIND_MY_SPAWNS);
     if (!spawn) return;
 
+    // Miners must remain on their reserved positions even if they are within
+    // the restricted area around the spawn. Skip the restricted tile check for
+    // that role so they don't get pushed away from containers.
     const roomMemory = Memory.rooms && Memory.rooms[creep.room.name];
-    if (roomMemory && roomMemory.restrictedArea) {
+    if (creep.memory.role !== 'miner' && roomMemory && roomMemory.restrictedArea) {
       for (const p of roomMemory.restrictedArea) {
         if (creep.pos.x === p.x && creep.pos.y === p.y) {
           creep.travelTo(spawn, { range: 2 });


### PR DESCRIPTION
## Summary
- place source containers using path to spawn
- remove obsolete buffer container construction
- exempt miners from spawn area avoidance
- ensure builders keep a main task and only spawn when 2 haulers exist
- document builder task memory in roles docs
- test builder task persistence

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68460c63a3648327ac6430b42ce12454