### PR TITLE
Fix container placement, drop spawn buffer

### DIFF
--- a/console.console.js
+++ b/console.console.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 var statsConsole = {
   run: function (data, logCpu = true, opts = {}) {
     if (Memory.stats === undefined) {
@@ -291,6 +293,58 @@ var statsConsole = {
           secondLineName = secondLineName.concat(["Stored Energy"]);
           secondLineStat = secondLineStat.concat(["0"]);
         }
+
+        const limits =
+          Memory.rooms && Memory.rooms[room.name]
+            ? Memory.rooms[room.name].spawnLimits || {}
+            : {};
+        const minersAlive = _.filter(
+          Game.creeps,
+          c => c.memory.role === 'miner' && c.room.name === room.name,
+        ).length;
+        const queuedMiners = (Memory.spawnQueue || []).filter(
+          q => q.room === room.name && q.memory.role === 'miner',
+        ).length;
+        secondLineName = secondLineName.concat(['Miners']);
+        secondLineStat = secondLineStat.concat([
+          `${minersAlive + queuedMiners}/${limits.miners || 0}`,
+        ]);
+
+        const haulersAlive = _.filter(
+          Game.creeps,
+          c => c.memory.role === 'hauler' && c.room.name === room.name,
+        ).length;
+        const queuedHaulers = (Memory.spawnQueue || []).filter(
+          q => q.room === room.name && q.memory.role === 'hauler',
+        ).length;
+        secondLineName = secondLineName.concat(['Haulers']);
+        secondLineStat = secondLineStat.concat([
+          `${haulersAlive + queuedHaulers}/${limits.haulers || 0}`,
+        ]);
+
+        const buildersAlive = _.filter(
+          Game.creeps,
+          c => c.memory.role === 'builder' && c.room.name === room.name,
+        ).length;
+        const queuedBuilders = (Memory.spawnQueue || []).filter(
+          q => q.room === room.name && q.memory.role === 'builder',
+        ).length;
+        secondLineName = secondLineName.concat(['Builders']);
+        secondLineStat = secondLineStat.concat([
+          `${buildersAlive + queuedBuilders}/${limits.builders || 0}`,
+        ]);
+
+        const upgradersAlive = _.filter(
+          Game.creeps,
+          c => c.memory.role === 'upgrader' && c.room.name === room.name,
+        ).length;
+        const queuedUpgraders = (Memory.spawnQueue || []).filter(
+          q => q.room === room.name && q.memory.role === 'upgrader',
+        ).length;
+        secondLineName = secondLineName.concat(['Upgraders']);
+        secondLineStat = secondLineStat.concat([
+          `${upgradersAlive + queuedUpgraders}/${limits.upgraders || 0}`,
+        ]);
       }
     }
 

--- a/docs/console.md
+++ b/docs/console.md
@@ -12,3 +12,8 @@ The console module renders an ASCII dashboard inside the Screeps client. It comb
   "Total" CPU line.
 
 The scheduler feeds data into the console module every tick. Use `statsConsole.displayStats()` to print the dashboard from the game console when needed.
+
+Each room section shows the stored energy along with workforce counts. The numbers are
+displayed as `current/max` for miners, haulers, builders and upgraders based on
+the latest spawn evaluation. This helps track whether the colony is meeting its
+target creep limits at a glance.

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -54,7 +54,7 @@ its queue is empty.
   - Containers are planned as soon as the room is claimed (RCL1).
   - Extensions begin construction when the controller reaches RCL2.
   - Source containers are prioritized before extensions, followed by controller
-    and buffer containers.
+    containers.
   - Mining positions are freed when miners approach expiry so replacements
     can claim the same spot. Any leftover reservations are cleared when
     miners or allPurpose creeps die.

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -18,14 +18,14 @@ Haulers remain governed by the energy demand module.
   range. Upgraders withdraw energy when adjacent to their container rather than
   only when positioned directly on top. When no containers are present the
   system still spawns one upgrader so progress never stalls.
-- **Builders** – Construction sites are prioritised by type. Extensions,
+ - **Builders** – Construction sites are prioritised by type. Extensions,
   containers and roads request up to four builders per site (maximum twelve).
-  Other sites spawn two builders each with the same overall cap. Builders keep
-  their assigned construction site until it is completed and remain near the
-  location while waiting for energy deliveries. While working they also collect
-  dropped energy or withdraw from nearby containers to minimise idle time.
-  Builders start working as soon as some energy is carried so partially filled
-  workers no longer idle.
+  Other sites spawn two builders each with the same overall cap. Builders claim
+  a site as their **main task** and store this ID in memory so they resume
+  building after fetching energy. Energy pickup or delivery requests are tracked
+  as a sub-task but never overwrite the build assignment. Builders start working
+  as soon as some energy is carried so partially filled workers no longer idle.
+  At least two haulers must exist before additional builders are spawned.
 
 The module updates `Memory.roleEval.lastRun` so a fallback task can throttle
 itself when CPU is scarce.

--- a/hive.roles.js
+++ b/hive.roles.js
@@ -23,6 +23,7 @@ const roles = {
     const minerWorkParts = minerBody.filter(p => p === WORK).length;
     const sources = room.find(FIND_SOURCES);
     let minersNeeded = 0;
+    let desiredMiners = 0;
     for (const source of sources) {
       const positions =
         Memory.rooms &&
@@ -33,6 +34,7 @@ const roles = {
           : null;
       if (!positions) continue;
       const maxMiners = Math.min(Object.keys(positions).length, 3);
+      desiredMiners += maxMiners;
 
       const liveCreeps = _.filter(
         Game.creeps,
@@ -113,6 +115,16 @@ const roles = {
 
     // --- Builder calculation ---
     const sites = room.find(FIND_CONSTRUCTION_SITES);
+    const haulersAlive = _.filter(
+      Game.creeps,
+      c => c.memory.role === 'hauler' && c.room.name === roomName,
+    ).length;
+    const queuedHaulers = spawnQueue.queue.filter(
+      q => q.memory.role === 'hauler' && q.room === roomName,
+    ).length;
+    const haulerTask = tasks.find(t => t.name === 'spawnHauler' && t.manager === 'spawnManager');
+    const haulerTaskAmount = haulerTask ? haulerTask.amount || 0 : 0;
+    const totalHaulers = haulersAlive + queuedHaulers + haulerTaskAmount;
     const important = sites.filter(
       s =>
         s.structureType === STRUCTURE_EXTENSION ||
@@ -123,6 +135,7 @@ const roles = {
     let desiredBuilders = 0;
     if (important.length > 0) desiredBuilders = Math.min(12, important.length * 4);
     else desiredBuilders = Math.min(12, general * 2);
+    if (totalHaulers < 2) desiredBuilders = 0;
     const liveBuilders = _.filter(
       Game.creeps,
       c => c.memory.role === 'builder' && c.room.name === roomName,
@@ -146,7 +159,17 @@ const roles = {
           'spawnManager',
         );
       statsConsole.log(`RoleEval queued ${buildersNeeded} builder(s) for ${roomName}`, 2);
+    } else if (builderTask && desiredBuilders === 0) {
+      const idx = container.tasks.indexOf(builderTask);
+      if (idx !== -1) container.tasks.splice(idx, 1);
     }
+
+    if (!Memory.rooms[roomName]) Memory.rooms[roomName] = {};
+    if (!Memory.rooms[roomName].spawnLimits)
+      Memory.rooms[roomName].spawnLimits = {};
+    Memory.rooms[roomName].spawnLimits.miners = desiredMiners;
+    Memory.rooms[roomName].spawnLimits.upgraders = desiredUpgraders;
+    Memory.rooms[roomName].spawnLimits.builders = desiredBuilders;
 
     Memory.roleEval.lastRun = Game.time;
   },

--- a/manager.building.js
+++ b/manager.building.js
@@ -96,7 +96,8 @@ const buildingManager = {
 
     if (room.controller.level >= 1) {
       this.buildControllerContainers(room);
-      this.buildBufferContainer(room);
+      // Buffer container near the spawn is no longer required
+      // this.buildBufferContainer(room);
     }
   },
 

--- a/manager.hivemind.demand.js
+++ b/manager.hivemind.demand.js
@@ -381,6 +381,11 @@ const demandModule = {
         2,
         Math.min(MAX_HAULERS_PER_ROOM, targetCalc),
       );
+      if (!Memory.rooms) Memory.rooms = {};
+      if (!Memory.rooms[roomName]) Memory.rooms[roomName] = {};
+      if (!Memory.rooms[roomName].spawnLimits)
+        Memory.rooms[roomName].spawnLimits = {};
+      Memory.rooms[roomName].spawnLimits.haulers = target;
       const toQueue = Math.max(0, target - currentAmount);
 
       if (

--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -82,6 +82,9 @@ const spawnModule = {
     if (myCreeps.length === 0 && !spawning) {
       // Emergency: purge existing queue and force a bootstrap creep
       const removed = spawnQueue.clearRoom(roomName);
+      if (container && container.tasks) {
+        _.remove(container.tasks, t => t.manager === 'spawnManager');
+      }
       if (!taskExists(roomName, 'spawnBootstrap', 'spawnManager')) {
         htm.addColonyTask(
           roomName,
@@ -97,6 +100,7 @@ const spawnModule = {
       if (removed > 0) {
         logger.log('hivemind.spawn', `Cleared ${removed} queued spawns due to panic in ${roomName}` , 3);
       }
+      return;
     }
 
   // Initial spawn sequence at RCL1 using strict role counts

--- a/manager.room.js
+++ b/manager.room.js
@@ -30,6 +30,20 @@ const roomManager = {
         { x: sourcePos.x - 1, y: sourcePos.y - 1 },
       ].filter(p => room.getTerrain().get(p.x, p.y) !== TERRAIN_MASK_WALL);
 
+      // Determine container spot along the path to the spawn
+      let pathPosition = null;
+      if (spawn) {
+        const result = PathFinder.search(
+          spawn.pos,
+          { pos: sourcePos, range: 1 },
+          { swampCost: 2, plainCost: 2, ignoreCreeps: true },
+        );
+        if (result.path && result.path.length > 0) {
+          const step = result.path[result.path.length - 1];
+          pathPosition = { x: step.x, y: step.y };
+        }
+      }
+
       potential.sort((a, b) =>
         spawn.pos.getRangeTo(a.x, a.y) - spawn.pos.getRangeTo(b.x, b.y),
       );
@@ -42,6 +56,8 @@ const roomManager = {
       if (containers.length > 0) {
         const cPos = containers[0].pos;
         bestPositions = [{ x: cPos.x, y: cPos.y }, ...potential.filter(p => p.x !== cPos.x || p.y !== cPos.y).slice(0, 2)];
+      } else if (pathPosition) {
+        bestPositions = [pathPosition, ...potential.filter(p => p.x !== pathPosition.x || p.y !== pathPosition.y).slice(0, 2)];
       }
 
       const mem = Memory.rooms[room.name].miningPositions[source.id] || { positions: {} };

--- a/role.builder.js
+++ b/role.builder.js
@@ -2,8 +2,8 @@ const htm = require('./manager.htm');
 const movementUtils = require('./utils.movement');
 
 function getIdlePos(creep) {
-  if (creep.memory.buildTarget) {
-    const target = Game.getObjectById(creep.memory.buildTarget);
+  if (creep.memory.mainTask && creep.memory.mainTask.type === 'build') {
+    const target = Game.getObjectById(creep.memory.mainTask.id);
     if (target) return target.pos;
   }
   const roomMemory = Memory.rooms && Memory.rooms[creep.room.name];
@@ -48,13 +48,13 @@ function requestEnergy(creep) {
  */
 function findNearbyEnergy(creep) {
   // Prefer dropped resources nearby to limit travel time
-  const dropped = creep.pos.findInRange(FIND_DROPPED_RESOURCES, 20, {
+  const dropped = creep.pos.findInRange(FIND_DROPPED_RESOURCES, 15, {
     filter: r => r.resourceType === RESOURCE_ENERGY && r.amount > 0,
   })[0];
   if (dropped) return { type: 'pickup', target: dropped };
 
   // Check nearby containers with available energy
-  const container = creep.pos.findInRange(FIND_STRUCTURES, 20, {
+  const container = creep.pos.findInRange(FIND_STRUCTURES, 15, {
     filter: s =>
       s.structureType === STRUCTURE_CONTAINER &&
       s.store[RESOURCE_ENERGY] > 0,
@@ -62,7 +62,7 @@ function findNearbyEnergy(creep) {
   if (container) return { type: 'withdraw', target: container };
 
   // Fallback to storage within reasonable distance
-  const storage = creep.pos.findInRange(FIND_STRUCTURES, 20, {
+  const storage = creep.pos.findInRange(FIND_STRUCTURES, 15, {
     filter: s =>
       s.structureType === STRUCTURE_STORAGE &&
       s.store &&
@@ -73,142 +73,140 @@ function findNearbyEnergy(creep) {
   return null;
 }
 
+function assignBuildTask(creep, entry, site, roomMemory) {
+  creep.memory.buildTarget = entry.id;
+  creep.memory.mainTask = { type: 'build', id: entry.id };
+  if (!roomMemory.siteAssignments) roomMemory.siteAssignments = {};
+  roomMemory.siteAssignments[entry.id] = (roomMemory.siteAssignments[entry.id] || 0) + 1;
+  htm.addCreepTask(
+    creep.name,
+    'buildStructure',
+    {
+      id: entry.id,
+      pos: { x: site.pos.x, y: site.pos.y, roomName: site.pos.roomName },
+    },
+    1,
+    50,
+    1,
+    'builder',
+  );
+}
+
+function clearBuildTask(creep, roomMemory) {
+  if (creep.memory.buildTarget && roomMemory && roomMemory.siteAssignments) {
+    roomMemory.siteAssignments[creep.memory.buildTarget] = Math.max(
+      0,
+      (roomMemory.siteAssignments[creep.memory.buildTarget] || 1) - 1,
+    );
+  }
+  delete creep.memory.buildTarget;
+  delete creep.memory.mainTask;
+}
+
+function gatherEnergy(creep) {
+  const idlePos = getIdlePos(creep);
+  if (idlePos && creep.pos.getRangeTo(idlePos) > 1) {
+    creep.travelTo(idlePos, { visualizePathStyle: { stroke: '#aaaaaa' }, range: 1 });
+    return;
+  }
+  const source = findNearbyEnergy(creep);
+  if (source) {
+    if (source.type === 'pickup') {
+      if (creep.pickup(source.target) === ERR_NOT_IN_RANGE) {
+        creep.travelTo(source.target, { visualizePathStyle: { stroke: '#ffaa00' } });
+      }
+    } else if (creep.withdraw(source.target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+      creep.travelTo(source.target, { visualizePathStyle: { stroke: '#ffaa00' } });
+    }
+  } else {
+    requestEnergy(creep);
+  }
+}
+
+function buildSite(creep, site) {
+  if (!site) return false;
+  if (creep.pos.isEqualTo(site.pos)) {
+    if (!movementUtils.stepOff(creep) && typeof creep.move === 'function') {
+      creep.move(1);
+    }
+    return true;
+  }
+  if (creep.build(site) === ERR_NOT_IN_RANGE) {
+    creep.travelTo(site, { visualizePathStyle: { stroke: '#ffffff' } });
+  }
+  return true;
+}
+
 const roleBuilder = {
   run: function (creep) {
     movementUtils.avoidSpawnArea(creep);
-    if (creep.memory.working && creep.store[RESOURCE_ENERGY] === 0) {
+    const roomMemory = (Memory.rooms && Memory.rooms[creep.room.name]) || {};
+
+    if (creep.store[RESOURCE_ENERGY] === 0) {
       creep.memory.working = false;
-      creep.say("🔄 collect");
     }
     if (!creep.memory.working && creep.store.getFreeCapacity() === 0) {
       creep.memory.working = true;
-      creep.say("⚡ build/repair");
     }
-    // Start working as soon as some energy is available to avoid idle creeps
     if (!creep.memory.working && creep.store[RESOURCE_ENERGY] > 0) {
       creep.memory.working = true;
-      creep.say("⚡ build/repair");
     }
 
-    if (creep.memory.working) {
-      const roomMemory = Memory.rooms[creep.room.name];
-      if (creep.store.getFreeCapacity() > 0) {
-        const nearby = findNearbyEnergy(creep);
-        if (nearby) {
-          if (nearby.type === 'pickup') {
-            if (creep.pickup(nearby.target) === ERR_NOT_IN_RANGE) {
-              creep.travelTo(nearby.target, { visualizePathStyle: { stroke: '#ffaa00' } });
-            }
-          } else if (creep.withdraw(nearby.target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-            creep.travelTo(nearby.target, { visualizePathStyle: { stroke: '#ffaa00' } });
+    const task = creep.memory.mainTask;
+
+    if (!task || (task.type === 'build' && !Game.getObjectById(task.id))) {
+      clearBuildTask(creep, roomMemory);
+    }
+
+    if (!creep.memory.mainTask) {
+      const queue = (creep.room.memory && creep.room.memory.buildingQueue) || [];
+      for (const entry of queue) {
+        const assigned = (roomMemory.siteAssignments && roomMemory.siteAssignments[entry.id]) || 0;
+        if (assigned < 4) {
+          const site = Game.getObjectById(entry.id);
+          if (site) {
+            assignBuildTask(creep, entry, site, roomMemory);
+            break;
           }
         }
       }
-      if (creep.memory.buildTarget) {
-        const site = Game.getObjectById(creep.memory.buildTarget);
-        if (!site) {
-          if (roomMemory && roomMemory.siteAssignments) {
-            roomMemory.siteAssignments[creep.memory.buildTarget] = Math.max(
-              0,
-              (roomMemory.siteAssignments[creep.memory.buildTarget] || 1) - 1,
-            );
-          }
-          delete creep.memory.buildTarget;
-        } else if (creep.pos.isEqualTo(site.pos)) {
-          movementUtils.stepOff(creep);
-          return;
-        } else if (creep.build(site) === ERR_NOT_IN_RANGE) {
-          creep.travelTo(site, { visualizePathStyle: { stroke: "#ffffff" } });
-          return;
-        }
+      if (!creep.memory.mainTask && queue.length === 0) {
+        creep.memory.mainTask = { type: 'upgrade', id: creep.room.controller.id };
       }
+    }
 
-      if (!creep.memory.buildTarget) {
-        const queue = creep.room.memory.buildingQueue || [];
-        for (const entry of queue) {
-          const assigned =
-            (roomMemory.siteAssignments && roomMemory.siteAssignments[entry.id]) ||
-            0;
-          if (assigned < 4) {
-            const site = Game.getObjectById(entry.id);
-            if (site) {
-              creep.memory.buildTarget = entry.id;
-              if (!roomMemory.siteAssignments) roomMemory.siteAssignments = {};
-              roomMemory.siteAssignments[entry.id] = assigned + 1;
-              htm.addCreepTask(
-                creep.name,
-                'buildStructure',
-                { id: entry.id, pos: { x: site.pos.x, y: site.pos.y, roomName: site.pos.roomName } },
-                1,
-                50,
-                1,
-                'builder',
-              );
-              if (creep.pos.isEqualTo(site.pos)) {
-                movementUtils.stepOff(creep);
-              } else if (creep.build(site) === ERR_NOT_IN_RANGE) {
-                creep.travelTo(site, { visualizePathStyle: { stroke: "#ffffff" } });
-              }
-              return;
-            }
-          }
-        }
-      }
+    if (!creep.memory.working) {
+      gatherEnergy(creep);
+      return;
+    }
 
-      if (!creep.memory.buildTarget && (creep.room.memory.buildingQueue || []).length === 0) {
-        const structuresNeedingRepair = creep.room.find(FIND_STRUCTURES, {
-          filter: (object) => object.hits < object.hitsMax,
-        });
-
-        structuresNeedingRepair.sort((a, b) => a.hits - b.hits);
-
-        if (structuresNeedingRepair.length > 0) {
-          if (creep.repair(structuresNeedingRepair[0]) === ERR_NOT_IN_RANGE) {
-            creep.travelTo(structuresNeedingRepair[0], {
-              visualizePathStyle: { stroke: "#ffffff" },
-            });
-          }
-        } else {
-          if (
-            creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE
-          ) {
-            creep.travelTo(creep.room.controller, {
-              visualizePathStyle: { stroke: "#ffffff" },
-            });
-          }
-        }
+    if (creep.memory.mainTask && creep.memory.mainTask.type === 'build') {
+      const site = Game.getObjectById(creep.memory.mainTask.id);
+      if (!buildSite(creep, site)) {
+        clearBuildTask(creep, roomMemory);
       }
     } else {
-      if (creep.store[RESOURCE_ENERGY] === 0) {
-        const idlePos = getIdlePos(creep);
-        if (idlePos && !creep.pos.inRangeTo(idlePos, 1)) {
-          creep.travelTo(idlePos, { visualizePathStyle: { stroke: '#aaaaaa' }, range: 1 });
+      if (creep.repair) {
+        const structuresNeedingRepair = creep.room.find(FIND_STRUCTURES, {
+          filter: o => o.hits < o.hitsMax,
+        });
+        structuresNeedingRepair.sort((a, b) => a.hits - b.hits);
+        if (structuresNeedingRepair.length > 0) {
+          if (creep.repair(structuresNeedingRepair[0]) === ERR_NOT_IN_RANGE) {
+            creep.travelTo(structuresNeedingRepair[0], { visualizePathStyle: { stroke: '#ffffff' } });
+          }
           return;
         }
-        const source = findNearbyEnergy(creep);
-        if (source) {
-          if (source.type === 'pickup') {
-            if (creep.pickup(source.target) === ERR_NOT_IN_RANGE) {
-              creep.travelTo(source.target, { visualizePathStyle: { stroke: '#ffaa00' } });
-            }
-          } else if (creep.withdraw(source.target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-            creep.travelTo(source.target, { visualizePathStyle: { stroke: '#ffaa00' } });
-          }
-        } else {
-          requestEnergy(creep);
-        }
+      }
+      if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
+        creep.travelTo(creep.room.controller, { visualizePathStyle: { stroke: '#ffffff' } });
       }
     }
   },
   onDeath: function (creep) {
-    if (creep.memory.buildTarget) {
-      const roomMemory = Memory.rooms && Memory.rooms[creep.room.name];
-      if (roomMemory && roomMemory.siteAssignments) {
-        roomMemory.siteAssignments[creep.memory.buildTarget] = Math.max(
-          0,
-          (roomMemory.siteAssignments[creep.memory.buildTarget] || 1) - 1,
-        );
-      }
+    const roomMemory = Memory.rooms && Memory.rooms[creep.room.name];
+    if (creep.memory.mainTask && creep.memory.mainTask.type === 'build') {
+      clearBuildTask(creep, roomMemory);
     }
   },
 };

--- a/test/avoidSpawnAreaMiner.test.js
+++ b/test/avoidSpawnAreaMiner.test.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const movementUtils = require('../utils.movement');
+
+global.FIND_MY_SPAWNS = 1;
+
+function createCreep(spawn) {
+  return {
+    memory: { role: 'miner' },
+    room: { name: 'W1N1' },
+    pos: {
+      x: 10,
+      y: 10,
+      roomName: 'W1N1',
+      findClosestByRange(type) {
+        if (type === FIND_MY_SPAWNS) return spawn;
+        return null;
+      },
+      isNearTo() { return false; },
+      getRangeTo(target) {
+        const dx = this.x - target.pos.x;
+        const dy = this.y - target.pos.y;
+        return Math.max(Math.abs(dx), Math.abs(dy));
+      },
+    },
+    travelTo() { moved = true; },
+  };
+}
+
+describe('avoidSpawnArea skips miners', function() {
+  let spawn;
+  let moved;
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawn = { pos: { x: 25, y: 25 } };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      find(type) { if (type === FIND_MY_SPAWNS) return [spawn]; return []; },
+    };
+    Memory.rooms = { W1N1: { restrictedArea: [{ x: 10, y: 10 }] } };
+    moved = false;
+  });
+
+  it('does not move miner off restricted tile', function() {
+    const creep = createCreep(spawn);
+    movementUtils.avoidSpawnArea(creep);
+    expect(moved).to.be.false;
+  });
+});

--- a/test/builderEnergy.test.js
+++ b/test/builderEnergy.test.js
@@ -61,4 +61,15 @@ describe('builder energy evaluation', function () {
     roleBuilder.run(creep);
     expect(Memory.htm.creeps['b2']).to.be.undefined;
   });
+
+  it('scans for energy within 15 tiles', function () {
+    const creep = createCreep('b3');
+    let rangeChecked = 0;
+    creep.pos.findInRange = (type, range) => {
+      rangeChecked = range;
+      return [];
+    };
+    roleBuilder.run(creep);
+    expect(rangeChecked).to.equal(15);
+  });
 });

--- a/test/builderTaskMemory.test.js
+++ b/test/builderTaskMemory.test.js
@@ -1,0 +1,53 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const htm = require('../manager.htm');
+const roleBuilder = require('../role.builder');
+
+global.FIND_MY_SPAWNS = 1;
+global.FIND_CONSTRUCTION_SITES = 2;
+global.STRUCTURE_CONTAINER = 'container';
+global.STRUCTURE_STORAGE = 'storage';
+global.RESOURCE_ENERGY = 'energy';
+global.OK = 0;
+
+describe('builder task memory', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    const site = { id: 's1', pos: { x: 1, y: 1, roomName: 'W1N1', lookFor: () => [] } };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      find: type => (type === FIND_CONSTRUCTION_SITES ? [site] : []),
+      memory: { buildingQueue: [{ id: 's1', priority: 100 }] },
+      controller: {},
+    };
+    Game.getObjectById = id => site;
+    Memory.rooms = { W1N1: { buildingQueue: [{ id: 's1', priority: 100 }], siteAssignments: {} } };
+  });
+
+  it('retains build task after requesting energy', function () {
+    const creep = {
+      name: 'b1',
+      room: Game.rooms['W1N1'],
+      store: { [RESOURCE_ENERGY]: 0, getFreeCapacity: () => 50 },
+      pos: {
+        x: 10,
+        y: 10,
+        roomName: 'W1N1',
+        getRangeTo: () => 1,
+        findInRange: () => [],
+      },
+      travelTo: () => {},
+      build: () => OK,
+      memory: {},
+    };
+    roleBuilder.run(creep);
+    expect(creep.memory.mainTask).to.deep.equal({ type: 'build', id: 's1' });
+    const tasks = Memory.htm.creeps['b1'].tasks;
+    const names = tasks.map(t => t.name);
+    expect(names).to.include('deliverEnergy');
+  });
+});
+

--- a/test/roleEvaluation.test.js
+++ b/test/roleEvaluation.test.js
@@ -58,4 +58,10 @@ describe('hive.roles evaluateRoom', function() {
     expect(t).to.exist;
     expect(t.amount).to.equal(3);
   });
+
+  it('stores spawn limits in room memory', function() {
+    roles.evaluateRoom(Game.rooms['W1N1']);
+    const limits = Memory.rooms['W1N1'].spawnLimits;
+    expect(limits).to.include.keys('miners', 'builders', 'upgraders');
+  });
 });

--- a/test/roomScanContainer.test.js
+++ b/test/roomScanContainer.test.js
@@ -1,0 +1,61 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const roomManager = require('../manager.room');
+
+// Constants required by roomManager
+global.FIND_SOURCES = 1;
+global.FIND_MY_SPAWNS = 2;
+global.FIND_STRUCTURES = 3;
+global.TERRAIN_MASK_WALL = 1;
+
+global.PathFinder = {
+  search(start, goal) {
+    return { path: [{ x: 11, y: 10 }], incomplete: false };
+  },
+};
+
+function getRangeTo(x1, y1, x2, y2) {
+  const dx = x1 - x2;
+  const dy = y1 - y2;
+  return Math.max(Math.abs(dx), Math.abs(dy));
+}
+
+describe('roomManager.scanRoom container placement', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    global.FIND_MY_SPAWNS = 2;
+    global.FIND_SOURCES = 1;
+    global.FIND_STRUCTURES = 3;
+    global.TERRAIN_MASK_WALL = 1;
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find(type) {
+        if (type === FIND_SOURCES) {
+          return [{ id: 's1', pos: { x: 10, y: 10 } }];
+        }
+        if (type === FIND_MY_SPAWNS) {
+          return [{ pos: { x: 25, y: 25, getRangeTo(targetX, targetY) {
+            if (typeof targetX === 'object') {
+              return getRangeTo(this.x, this.y, targetX.x, targetX.y);
+            }
+            return getRangeTo(this.x, this.y, targetX, targetY);
+          } } }];
+        }
+        if (type === FIND_STRUCTURES) return [];
+        return [];
+      },
+      getTerrain() {
+        return { get() { return 0; } };
+      },
+    };
+  });
+
+  it('stores path-based container position as best1', function() {
+    roomManager.scanRoom(Game.rooms['W1N1']);
+    const pos = Memory.rooms.W1N1.miningPositions.s1.positions.best1;
+    expect(pos).to.deep.equal({ x: 11, y: 10, roomName: 'W1N1', reserved: false });
+  });
+});

--- a/utils.movement.js
+++ b/utils.movement.js
@@ -8,8 +8,11 @@ const movementUtils = {
     const spawn = creep.pos.findClosestByRange(FIND_MY_SPAWNS);
     if (!spawn) return;
 
+    // Miners must remain on their reserved positions even if they are within
+    // the restricted area around the spawn. Skip the restricted tile check for
+    // that role so they don't get pushed away from containers.
     const roomMemory = Memory.rooms && Memory.rooms[creep.room.name];
-    if (roomMemory && roomMemory.restrictedArea) {
+    if (creep.memory.role !== 'miner' && roomMemory && roomMemory.restrictedArea) {
       for (const p of roomMemory.restrictedArea) {
         if (creep.pos.x === p.x && creep.pos.y === p.y) {
           creep.travelTo(spawn, { range: 2 });


### PR DESCRIPTION
## Summary
- handle colony panic by clearing spawn tasks before queuing bootstrap
- track desired creep counts per room and show them in console stats
- builders search for energy within 15 tiles
- expose spawn limits in room memory
- update tests for revised spawn flow and stats output

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68460c63a3648327ac6430b42ce12454