### PR TITLE
Add introspection commands and document memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Below is a high-level checklist tracking progress. Priority ranges from 1 (low) 
 Next step: focus on the hierarchical task system so the scheduler can trigger colony and creep level tasks dynamically.
 
 ## 📘 Documentation
+- [System Overview](./docs/SYSTEM_OVERVIEW.md)
 - [Roadmap](./ROADMAP.md)
 - [Logger](./docs/logger.md)
 - [Scheduler](./docs/scheduler.md)

--- a/debug.introspection.js
+++ b/debug.introspection.js
@@ -1,0 +1,44 @@
+const htm = require('./manager.htm');
+const scheduler = require('./scheduler');
+const memoryManager = require('./manager.memory');
+const statsConsole = require('console.console');
+
+module.exports = {
+  /** Print all active HTM tasks */
+  printHTMTasks() {
+    const tasks = htm.listTasks();
+    if (tasks.length === 0) {
+      statsConsole.log('No active HTM tasks', 2);
+      return;
+    }
+    for (const t of tasks) {
+      const status = Game.time < t.claimedUntil ? 'claimed' : 'open';
+      const ttl = t.ttl - t.age;
+      statsConsole.log(
+        `[${t.level}] ${t.name} ${t.id} ${status} ttl:${ttl} origin:${t.origin.module}`,
+        2,
+      );
+    }
+  },
+
+  /** Print scheduler job timings */
+  printSchedulerJobs() {
+    const list = scheduler.listTasks();
+    const show = (arr) => arr.map((t) => `${t.name}@${t.nextRun}`).join(', ') || 'none';
+    statsConsole.log(`HP: ${show(list.high)}`, 2);
+    statsConsole.log(`Tasks: ${show(list.normal)}`, 2);
+    for (const e in list.events) {
+      statsConsole.log(`${e}: ${show(list.events[e])}`, 2);
+    }
+  },
+
+  /** Print memory version status for all schemas */
+  printMemoryStatus() {
+    const report = memoryManager.getVersionStatus();
+    for (const entry of report) {
+      const ok = entry.current === entry.expected;
+      const msg = `${entry.path}: ${entry.current || 'n/a'} (expected ${entry.expected})`;
+      statsConsole.log(msg, ok ? 2 : 4);
+    }
+  },
+};

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -1,0 +1,20 @@
+# 🗺 System Overview
+
+This document maps the main subsystems of the Tyranid Screeps AI and how they interact.
+
+| Subsystem | Description | Docs |
+|-----------|-------------|------|
+| **Scheduler** | Orchestrates recurring jobs and event reactions. | [Scheduler](./scheduler.md) |
+| **HTM** | Hierarchical Task Manager that stores and executes tasks. | [Tasks](./tasks.md) |
+| **Memory Manager** | Maintains versioned memory layout and migrations. | [Memory](./memory.md) |
+| **HiveMind** | Strategic layer queuing tasks based on game state. | [HiveMind](./hivemind.md) |
+| **Spawn Queue** | Buffers creep spawn requests for processing. | [Spawn Queue](./spawnQueue.md) |
+| **Demand Tracker** | Records energy demand/delivery metrics. | section in [Memory](./memory.md) |
+
+```
+Scheduler -> HiveMind -> HTM -> Spawn Queue -> Spawn Manager -> Creeps
+                \-> Demand Tracker ----/
+```
+
+Use the global `debug` helpers to inspect the current schedule (`debug.showSchedule()`),
+active tasks (`debug.showHTM()`), and memory schema versions (`debug.memoryStatus()`).

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,115 @@
+# 🗄️ Memory Layout
+
+This file documents the persistent memory schema used by Tyranid Screeps.  All modules interact with memory through these namespaces.  Each module owns its branch and is responsible for migrations when the schema version changes.
+
+## Schema Versions
+
+`Memory.hive.version` tracks the current hive schema.  `memory.migrations.js`
+defines `MEMORY_VERSION` and migration steps applied whenever the stored version
+is lower.  Version `2` adds a demand namespace.
+
+```javascript
+Memory.hive = {
+  version: 2,
+  clusters: {
+    [clusterId]: {
+      meta: {},
+      colonies: {
+        [colonyId]: {
+          meta: {},
+          creeps: {},
+          structures: {},
+          tasks: {},
+        }
+      }
+    }
+  }
+};
+```
+
+`manager.memory.js` ensures this layout exists via `initializeHiveMemory(clusterId, colonyId)`.
+
+## Module Ownership
+
+- **memoryManager** – owns `Memory.hive` and `Memory.rooms`.
+- **HTM** – stores task queues under `Memory.htm`.
+- **spawnQueue** – uses `Memory.spawnQueue` and `Memory.nextSpawnRequestId`.
+- **demand module** – stores delivery metrics under `Memory.demand`.
+- **logger/statsConsole** – maintain `Memory.stats`.
+
+Modules must only modify their own branches.
+
+## Initialization Defaults
+
+Room initialization populates `Memory.rooms[roomName]` with:
+
+```javascript
+{
+  miningPositions: {},
+  reservedPositions: {},
+  restrictedArea: []
+}
+```
+
+Cluster and colony memory follow the defaults in `manager.memory.js`.
+
+## Adding New Schemas
+
+When a module requires persistent storage it should register its schema and version in `memory.schemas.js` so documentation can be generated automatically.  Migration functions can read `Memory.hive.version` to upgrade data structures.
+The registry is a simple object mapping keys to `{ version, owner }` pairs.  Codex uses this file to produce the table of memory layouts.
+
+When the hive starts, `initializeHiveMemory` checks `Memory.hive.version` and
+runs any migrations registered in `memory.migrations.js`. Each migration updates
+older layouts so the AI can evolve without wiping persistent data.
+
+### Spawn Queue
+
+@codex-owner spawnQueue
+@codex-path Memory.spawnQueue
+@codex-version 1
+
+`Memory.spawnQueue` holds pending creep requests. Each entry is an object:
+
+```javascript
+{
+  requestId: 'time-counter',
+  category: 'miner',
+  room: 'W1N1',
+  bodyParts: [WORK, MOVE],
+  memory: { role: 'miner' },
+  spawnId: '5abc123',
+  ticksToSpawn: 0,
+  energyRequired: 300,
+  priority: 2
+}
+```
+
+`Memory.nextSpawnRequestId` increments each tick to ensure unique ids. Requests
+are sorted by `priority` and `ticksToSpawn` when processed by
+`manager.spawnQueue`.
+
+### Energy Demand Tracking
+
+@codex-owner hivemind.demand
+@codex-path Memory.demand
+@codex-version 1
+
+Tracks how much energy structures request and how much creeps deliver. Layout:
+
+```javascript
+Memory.demand = {
+  rooms: {
+    [roomName]: {
+      requesters: { [id]: { lastEnergyRequested, deliveries, averageRequested } },
+      deliverers: { [name]: { role, deliveries, averageEnergy } },
+      totals: { demand: 0, supply: 0, demandRate: 0, supplyRate: 0 },
+      runNextTick: false
+    }
+  },
+  globalTotals: { demand: 0, supply: 0, demandRate: 0, supplyRate: 0 }
+};
+```
+
+The demand module updates these metrics every tick and decides when additional
+haulers should be spawned.
+

--- a/docs/spawnQueue.md
+++ b/docs/spawnQueue.md
@@ -45,3 +45,13 @@ processing.
 In panic situations the HiveMind may purge all pending requests for a room. Use
 `spawnQueue.clearRoom(roomName)` to remove every queued entry belonging to that
 room.
+
+### Memory Layout
+
+@codex-owner spawnQueue
+@codex-path Memory.spawnQueue
+@codex-version 1
+
+`Memory.spawnQueue` is an array containing the request objects shown above.
+`Memory.nextSpawnRequestId` increments each tick to guarantee unique ids.
+Requests are removed once the spawn succeeds or they are explicitly cleared.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,111 @@
+# ⚙️ HTM Tasks
+
+This document lists common task types used by the Hierarchical Task Manager.  Tasks originate from HiveMind modules and are executed by managers or creeps via lifecycle hooks.
+
+Each task object contains:
+
+```javascript
+{
+  name: 'spawnMiner',
+  data: {},
+  priority: 1,  // lower runs first
+  ttl: 100,     // expiration in ticks
+  age: 0,
+  amount: 1,
+  manager: 'spawnManager',
+  claimedUntil: 0,
+  origin: { module: 'hive.roles', createdBy: 'evaluateRoom', tickCreated: 123 }
+  parentTaskId: null,
+  subtaskIds: [],
+}
+```
+
+`origin` records which module queued the task, the function that created it and
+the tick. This helps trace behaviour in the console or a future GUI.
+
+## Default Lifecycle
+
+1. **execute(data)** – main handler registered via `htm.registerHandler`.
+2. **onSuccess(data)** – optional success hook.
+3. **onFail(data, reason)** – optional failure hook.
+
+Handlers may schedule subtasks or update memory.  Failed tasks are retried until `ttl` expires.
+
+## Trigger Types
+
+Tasks can specify when they should run using a trigger object in the
+task registry:
+
+```javascript
+taskRegistry.register('upgradeController', {
+  priority: 2,
+  ttl: 50,
+  trigger: { type: 'event', eventName: 'controllerUpgrade' },
+});
+```
+
+- **tick** – processed every HTM run. You may provide `tickAt` to delay the
+  first execution until a future tick.
+- **event** – queued when `scheduler.triggerEvent(eventName)` is fired.
+- **condition** – `conditionFn` is evaluated each HTM run and the task is
+  queued when it returns `true`.
+
+## Example Tasks
+
+| Task Name        | Owner Module      | Default Priority | Purpose                         |
+|------------------|------------------|-----------------|---------------------------------|
+| `spawnMiner`     | `spawnManager`   | 1               | Request a miner in a colony.    |
+| `spawnHauler`    | `spawnManager`   | 1               | Request a hauler creep.         |
+| `upgradeController` | `hivemind.spawn` | 3             | Encourage controller upgrades.  |
+| `deliverEnergy`  | `energyRequests` | 2               | Hauler delivery to a structure. |
+| `defendRoom`     | `hivemind.spawn` | 1               | Spawn defenders on hostiles.    |
+
+Past executions can be inspected under `Memory.stats.taskLogs` when a module chooses to record them.
+
+### Composite Tasks
+
+Tasks may reference a parent task and maintain a list of subtasks. This allows
+complex objectives to be broken into smaller steps while maintaining a tree
+structure.
+
+```javascript
+htm.addColonyTask(
+  'W1N1',
+  'buildExtensions',
+  {},
+  2,
+  50,
+  1,
+  'buildingManager',
+  {},
+  { parentTaskId: '123', subtaskIds: ['123-1', '123-2'] },
+);
+```
+
+The HTM does not currently enforce parent/child relationships but the fields are
+available for future visualisation and debugging tools.
+
+
+### Task Registry
+
+Metadata for each task type can be registered via `taskRegistry.register(name, meta)`.
+This enables automated documentation and potential GUI visualisation.
+
+Example:
+```javascript
+const taskRegistry = require('taskRegistry');
+taskRegistry.register('spawnMiner', { priority: 1, ttl: 20, owner: 'spawnManager' });
+```
+
+`meta` may include `trigger` information and descriptive fields for documentation:
+
+```javascript
+taskRegistry.register('deliverEnergy', {
+  priority: 2,
+  ttl: 30,
+  owner: 'energyRequests',
+  trigger: { type: 'condition', conditionFn: needsEnergy },
+});
+```
+
+Registered entries are exposed through `taskRegistry.registry` and may be exported to Codex docs.

--- a/main.js
+++ b/main.js
@@ -15,6 +15,7 @@ const memoryManager = require("manager.memory");
 const hiveTravel = require("manager.hiveTravel");
 const scheduler = require("scheduler");
 const logger = require("./logger");
+const introspect = require('./debug.introspection');
 const htm = require("manager.htm");
 const hivemind = require("manager.hivemind");
 const movementUtils = require("./utils.movement");
@@ -76,6 +77,15 @@ global.debug = {
     }
   },
   config: logger.getConfig,
+  showHTM() {
+    introspect.printHTMTasks();
+  },
+  showSchedule() {
+    introspect.printSchedulerJobs();
+  },
+  memoryStatus() {
+    introspect.printMemoryStatus();
+  },
 };
 
 // High priority initialization tasks - run once at start of tick 0
@@ -91,7 +101,7 @@ scheduler.addTask(
     }
   },
   { highPriority: true, once: true },
-);
+); // @codex-owner main @codex-trigger once
 
 scheduler.addTask("clearMemory", 100, () => {
   const roleMap = {
@@ -123,7 +133,7 @@ scheduler.addTask("clearMemory", 100, () => {
     }
   }
   if (removed) scheduler.triggerEvent('roleUpdate', {});
-});
+}); // @codex-owner main @codex-trigger {"type":"interval","interval":100}
 
 
 scheduler.addTask("updateHUD", 5, () => {
@@ -136,7 +146,7 @@ scheduler.addTask("updateHUD", 5, () => {
       distanceTransform.visualizeDistanceTransform(roomName, dist);
     }
   }
-});
+}); // @codex-owner main @codex-trigger {"type":"interval","interval":5}
 
 
 // Add on-demand building manager task
@@ -145,16 +155,16 @@ scheduler.addTask("buildInfrastructure", 0, () => {
     const room = Game.rooms[roomName];
     buildingManager.buildInfrastructure(room);
   }
-});
+}); // @codex-owner buildingManager @codex-trigger {"type":"interval","interval":0}
 
 // Decision making layer feeding tasks into HTM
 scheduler.addTask("hivemind", 1, () => {
   hivemind.run();
-});
+}); // @codex-owner hivemind @codex-trigger {"type":"interval","interval":1}
 
 scheduler.addTask("energyDemand", 1000, () => {
   energyDemand.run();
-});
+}); // @codex-owner demand @codex-trigger {"type":"interval","interval":1000}
 
 // React to creep deaths, spawns and construction updates
 scheduler.addTask('roleUpdateEvent', 0, (data) => {
@@ -166,7 +176,7 @@ scheduler.addTask('roleUpdateEvent', 0, (data) => {
       if (r.controller && r.controller.my) hiveRoles.evaluateRoom(r);
     }
   }
-}, { event: 'roleUpdate' });
+}, { event: 'roleUpdate' }); // @codex-owner main @codex-trigger {"type":"event","eventName":"roleUpdate"}
 
 // Fallback evaluation every 50 ticks when bucket high
 scheduler.addTask('roleUpdateFallback', 50, () => {
@@ -177,11 +187,11 @@ scheduler.addTask('roleUpdateFallback', 50, () => {
       if (r.controller && r.controller.my) hiveRoles.evaluateRoom(r);
     }
   }
-});
+}); // @codex-owner main @codex-trigger {"type":"interval","interval":50}
 // Core HTM execution task
 scheduler.addTask("htmRun", 1, () => {
   htm.run();
-});
+}); // @codex-owner htm @codex-trigger {"type":"interval","interval":1}
 
 // Scheduled console drawing
 scheduler.addTask(
@@ -198,17 +208,17 @@ scheduler.addTask(
     Memory.stats.consoleDrawTime = drawTime;
   },
   { minBucket: 1000 },
-);
+); // @codex-owner console.console @codex-trigger {"type":"interval","interval":5}
 
 // Periodically purge console log counts to avoid memory bloat
 scheduler.addTask('purgeLogs', 250, () => {
   memoryManager.purgeConsoleLogCounts();
-});
+}); // @codex-owner memoryManager @codex-trigger {"type":"interval","interval":250}
 
 // Cleanup stale HTM creep containers
 scheduler.addTask('htmCleanup', 50, () => {
   htm.cleanupDeadCreeps();
-});
+}); // @codex-owner htm @codex-trigger {"type":"interval","interval":50}
 
 // Debug listing of scheduled tasks
 scheduler.addTask(
@@ -220,7 +230,7 @@ scheduler.addTask(
     }
   },
   { minBucket: 0 },
-);
+); // @codex-owner scheduler @codex-trigger {"type":"interval","interval":50}
 
 module.exports.loop = function () {
   const startCPU = Game.cpu.getUsed();

--- a/memory.migrations.js
+++ b/memory.migrations.js
@@ -1,0 +1,43 @@
+"use strict";
+
+/**
+ * Global memory migrations executed when `Memory.hive.version` is behind
+ * the current `MEMORY_VERSION` constant.
+ * @codex-owner memoryManager
+ * @codex-version 2
+ */
+const MEMORY_VERSION = 2;
+
+/**
+ * Array of migration steps in ascending order.
+ * Each migration exposes a `version` and `migrate()` function.
+ * @type {Array<{version:number, migrate:function}>}
+ */
+const migrations = [
+  {
+    version: 2,
+    migrate() {
+      if (!Memory.demand) Memory.demand = { rooms: {}, nextId: 1 };
+    },
+  },
+];
+
+/**
+ * Run all migrations newer than the given version.
+ * @param {number} currentVersion
+ */
+function runMigrations(currentVersion) {
+  for (const step of migrations) {
+    if (step.version > currentVersion) {
+      try {
+        step.migrate();
+      } catch (err) {
+        console.log(`Migration ${step.version} failed: ${err}`);
+      }
+    }
+  }
+  if (!Memory.hive) Memory.hive = { clusters: {} };
+  Memory.hive.version = MEMORY_VERSION;
+}
+
+module.exports = { MEMORY_VERSION, runMigrations, migrations };

--- a/memory.schemas.js
+++ b/memory.schemas.js
@@ -1,0 +1,15 @@
+/**
+ * Registry for memory schema versions used by modules.
+ * Each entry documents default values so Codex can build documentation.
+ * @codex-owner memoryManager
+ */
+const schemas = {
+  /** @codex-path Memory.hive */
+  hive: { version: 2, owner: 'memoryManager', path: 'Memory.hive' },
+  /** @codex-path Memory.demand */
+  demand: { version: 1, owner: 'hivemind.demand', path: 'Memory.demand' },
+  /** @codex-path Memory.spawnQueue */
+  spawnQueue: { version: 1, owner: 'spawnQueue', path: 'Memory.spawnQueue' },
+};
+
+module.exports = schemas;

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,4 +1,13 @@
 /**
+ * Trigger definition shared by scheduler jobs and HTM tasks.
+ * @typedef {Object} Trigger
+ * @property {'interval'|'event'|'once'} type
+ * @property {number} [interval]
+ * @property {string} [eventName]
+ * @property {number} [tickAt]
+ */
+
+/**
  * Represents a single scheduled task.
  */
 const statsConsole = require('console.console');
@@ -14,6 +23,12 @@ class Task {
     this.event = options.event || null;
     this.minBucket = options.minBucket || 0; // Minimum CPU bucket to execute
     this.executed = false; // Track if the task ran at least once
+    /** @type {Trigger} */
+    this.trigger = this.event
+      ? { type: 'event', eventName: this.event }
+      : this.once
+      ? { type: 'once', tickAt: this.nextRun }
+      : { type: 'interval', interval: this.interval };
   }
 }
 
@@ -58,6 +73,7 @@ class Scheduler {
    * @param {boolean} [options.highPriority=false] Execute before other tasks.
    * @param {boolean} [options.once=false]  Remove task after first execution.
    * @param {string}  [options.event=null]  Event name to bind this task to.
+   * @codex-owner scheduler
    */
   addTask(name, interval, taskFunction, options = {}) {
     const task = new Task(name, interval, taskFunction, options);

--- a/taskRegistry.js
+++ b/taskRegistry.js
@@ -1,0 +1,28 @@
+/**
+ * Simple registry storing metadata about HTM tasks.
+ * Allows docs and GUI tools to introspect available task types.
+ * @codex-owner htm
+ */
+const registry = {};
+
+/**
+ * Register a task with descriptive metadata.
+ * @param {string} name - Unique task name.
+ * @param {object} meta - Information such as default priority or TTL.
+ * @param {Trigger} [meta.trigger] - When and how the task should run.
+ * @param {string} meta.owner - Owning module.
+ */
+function register(name, meta) {
+  registry[name] = meta;
+}
+
+/**
+ * Retrieve metadata for a task name.
+ * @param {string} name
+ * @returns {object|undefined}
+ */
+function get(name) {
+  return registry[name];
+}
+
+module.exports = { register, get, registry };

--- a/test/htmListTasks.test.js
+++ b/test/htmListTasks.test.js
@@ -1,0 +1,19 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const htm = require('../manager.htm');
+
+describe('htm listTasks', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    htm.addColonyTask('W1N1', 'spawnMiner');
+  });
+
+  it('returns tasks with level info', function() {
+    const list = htm.listTasks();
+    expect(list).to.have.length(1);
+    expect(list[0].level).to.equal('colony');
+    expect(list[0].name).to.equal('spawnMiner');
+  });
+});

--- a/test/memoryMigration.test.js
+++ b/test/memoryMigration.test.js
@@ -1,0 +1,17 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const { runMigrations, MEMORY_VERSION } = require('../memory.migrations');
+
+describe('memory migrations', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    Memory.hive = { version: 1, clusters: {} };
+  });
+
+  it('runs migrations and updates version', function() {
+    runMigrations(1);
+    expect(Memory.hive.version).to.equal(MEMORY_VERSION);
+    expect(Memory.demand).to.be.an('object');
+  });
+});


### PR DESCRIPTION
## Summary
- provide debug introspection module for tasks, scheduler, and memory versions
- extend HTM tasks with IDs, parent/subtask references, and execution logging
- expose debug helpers via `global.debug` for live inspection
- document spawnQueue and demand memory schemas and system overview
- add test for new `htm.listTasks`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68492ff76ba08327b2d487fb47fc2749