### PR TITLE
Document memory schemas and task registry

### DIFF
--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -10,6 +10,8 @@ This document maps the main subsystems of the Tyranid Screeps AI and how they in
 | **HiveMind** | Strategic layer queuing tasks based on game state. | [HiveMind](./hivemind.md) |
 | **Spawn Queue** | Buffers creep spawn requests for processing. | [Spawn Queue](./spawnQueue.md) |
 | **Demand Tracker** | Records energy demand/delivery metrics. | section in [Memory](./memory.md) |
+| **HiveTravel** | Pathing helper storing hostile rooms under `Memory.empire`. | part of [Memory](./memory.md) |
+| **Logger** | Aggregates stats and console output in `Memory.stats`. | [Logger](./logger.md) |
 
 ```
 Scheduler -> HiveMind -> HTM -> Spawn Queue -> Spawn Manager -> Creeps

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -36,6 +36,9 @@ Memory.hive = {
 - **spawnQueue** – uses `Memory.spawnQueue` and `Memory.nextSpawnRequestId`.
 - **demand module** – stores delivery metrics under `Memory.demand`.
 - **logger/statsConsole** – maintain `Memory.stats`.
+- **main** – user toggles stored under `Memory.settings`.
+- **hive.roles** – evaluation timestamps in `Memory.roleEval`.
+- **hiveTravel** – hostile room data in `Memory.empire`.
 
 Modules must only modify their own branches.
 
@@ -112,4 +115,55 @@ Memory.demand = {
 
 The demand module updates these metrics every tick and decides when additional
 haulers should be spawned.
+
+### Runtime Settings
+
+@codex-owner main
+@codex-path Memory.settings
+@codex-version 1
+
+Stores toggles for optional features such as HUD visuals or task listing.
+Example:
+
+```javascript
+Memory.settings = {
+  enableVisuals: true,
+  showTaskList: false,
+};
+```
+
+### Role Evaluation
+
+@codex-owner hive.roles
+@codex-path Memory.roleEval
+@codex-version 1
+
+Used to throttle automatic role evaluation when CPU is scarce.
+
+```javascript
+Memory.roleEval = { lastRun: 0 };
+```
+
+### Empire Data
+
+@codex-owner hiveTravel
+@codex-path Memory.empire
+@codex-version 1
+
+Legacy storage for hostile room information used by the pathing system.
+
+```javascript
+Memory.empire = {
+  hostileRooms: { [roomName]: true }
+};
+```
+
+### Statistics
+
+@codex-owner logger
+@codex-path Memory.stats
+@codex-version 1
+
+Console and task execution metrics are aggregated here.
+`Memory.stats.taskLogs` keeps the most recent task executions.
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -75,3 +75,5 @@ The main loop registers several core jobs which drive the colony:
 
 Use `scheduler.listTasks()` to see current timers and next execution tick for each job.
 
+`consoleDisplay` only executes when the CPU bucket exceeds 1000 thanks to its `minBucket` setting. Likewise `showScheduled` respects `Memory.settings.showTaskList` before printing.
+

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -59,6 +59,18 @@ taskRegistry.register('upgradeController', {
 | `upgradeController` | `hivemind.spawn` | 3             | Encourage controller upgrades.  |
 | `deliverEnergy`  | `energyRequests` | 2               | Hauler delivery to a structure. |
 | `defendRoom`     | `hivemind.spawn` | 1               | Spawn defenders on hostiles.    |
+| `spawnBootstrap` | `spawnManager`   | 0               | Emergency worker when none exist. |
+
+### Registered Triggers
+
+| Task              | Trigger                                        |
+|-------------------|-----------------------------------------------|
+| `spawnMiner`      | condition via `hive.roles` evaluation          |
+| `spawnHauler`     | condition via energy demand analysis           |
+| `spawnBootstrap`  | condition when no workers are present          |
+| `upgradeController` | event `roleUpdate` or energy surplus check    |
+| `defendRoom`      | event `hostilesDetected`                       |
+| `deliverEnergy`   | condition when structure free capacity > 0     |
 
 Past executions can be inspected under `Memory.stats.taskLogs` when a module chooses to record them.
 

--- a/main.js
+++ b/main.js
@@ -16,6 +16,7 @@ const hiveTravel = require("manager.hiveTravel");
 const scheduler = require("scheduler");
 const logger = require("./logger");
 const introspect = require('./debug.introspection');
+require('./taskDefinitions');
 const htm = require("manager.htm");
 const hivemind = require("manager.hivemind");
 const movementUtils = require("./utils.movement");

--- a/memory.schemas.js
+++ b/memory.schemas.js
@@ -10,6 +10,14 @@ const schemas = {
   demand: { version: 1, owner: 'hivemind.demand', path: 'Memory.demand' },
   /** @codex-path Memory.spawnQueue */
   spawnQueue: { version: 1, owner: 'spawnQueue', path: 'Memory.spawnQueue' },
+  /** @codex-path Memory.empire */
+  empire: { version: 1, owner: 'hiveTravel', path: 'Memory.empire' },
+  /** @codex-path Memory.settings */
+  settings: { version: 1, owner: 'main', path: 'Memory.settings' },
+  /** @codex-path Memory.roleEval */
+  roleEval: { version: 1, owner: 'hive.roles', path: 'Memory.roleEval' },
+  /** @codex-path Memory.stats */
+  stats: { version: 1, owner: 'logger', path: 'Memory.stats' },
 };
 
 module.exports = schemas;

--- a/taskDefinitions.js
+++ b/taskDefinitions.js
@@ -1,0 +1,47 @@
+const taskRegistry = require('./taskRegistry');
+
+// Register common HTM tasks with metadata so the docs can reference them.
+
+taskRegistry.register('spawnMiner', {
+  owner: 'spawnManager',
+  priority: 1,
+  ttl: 20,
+  trigger: { type: 'condition', conditionFn: 'hive.roles.evaluateRoom' },
+});
+
+taskRegistry.register('spawnHauler', {
+  owner: 'spawnManager',
+  priority: 1,
+  ttl: 20,
+  trigger: { type: 'condition', conditionFn: 'demand.analyse' },
+});
+
+taskRegistry.register('spawnBootstrap', {
+  owner: 'spawnManager',
+  priority: 0,
+  ttl: 20,
+  trigger: { type: 'condition', conditionFn: 'hivemind.spawn.bootstrap' },
+});
+
+taskRegistry.register('upgradeController', {
+  owner: 'hivemind.spawn',
+  priority: 3,
+  ttl: 50,
+  trigger: { type: 'event', eventName: 'roleUpdate' },
+});
+
+taskRegistry.register('deliverEnergy', {
+  owner: 'energyRequests',
+  priority: 2,
+  ttl: 30,
+  trigger: { type: 'condition', conditionFn: 'structureNeedsEnergy' },
+});
+
+taskRegistry.register('defendRoom', {
+  owner: 'hivemind.spawn',
+  priority: 1,
+  ttl: 20,
+  trigger: { type: 'event', eventName: 'hostilesDetected' },
+});
+
+module.exports = taskRegistry;


### PR DESCRIPTION
## Summary
- document new memory segments and schemas
- register common HTM tasks with triggers
- require the task registration in `main.js`
- expand scheduler documentation with CPU hints
- add subsystem notes to SYSTEM_OVERVIEW

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68493b48f4f88327bc793efc6389caf9