### PR TITLE
Improve allPurpose role resilience with fallback mode

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -50,7 +50,8 @@ Room initialization populates `Memory.rooms[roomName]` with:
 {
   miningPositions: {},
   reservedPositions: {},
-  restrictedArea: []
+  restrictedArea: [],
+  controllerUpgradeSpots: 0
 }
 ```
 
@@ -166,4 +167,25 @@ Memory.empire = {
 
 Console and task execution metrics are aggregated here.
 `Memory.stats.taskLogs` keeps the most recent task executions.
+
+### Creep Fallback State
+
+@codex-owner role.allPurpose
+@codex-path creep.memory.fallbackReason
+
+All-purpose creeps temporarily record fallback information when required
+room data is missing. These fields are cleared once normal behaviour resumes.
+
+```javascript
+creep.memory.fallbackReason = 'missingMiningData';
+creep.memory.fallbackSince = Game.time;
+```
+
+### Controller Upgrade Spots
+
+@codex-owner manager.room
+@codex-path Memory.rooms[roomName].controllerUpgradeSpots
+
+Number of walkable tiles within range 3 of the controller. Used to cap dedicated
+upgraders.
 

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -12,20 +12,14 @@ Haulers remain governed by the energy demand module.
    `manager.dna` and capped at three creeps per source. Miners with at least five
    WORK parts automatically relocate onto the nearby container so they can empty
    the source without moving.
- - **Upgraders** – A single container two tiles from the controller anchors the
-  upgrade position. Upgraders stand on or next to this container and withdraw
-  energy before upgrading from range. They top up whenever the container has
-  energy available so upgrading rarely pauses. When the container is missing the
-  HiveMind still spawns one upgrader so progress never stalls.
- - **Builders** – Always fetch energy from nearby containers, storage or dropped
-   resources before requesting delivery. They select the highest priority
-   construction site each tick (extensions first, then containers, then other
-  structures) and build until empty. Each builder stores its assigned
-  construction site's id in `creep.memory.mainTask` so it will return after
-  refueling. Builders begin working as soon as they carry any energy. At least
-  two haulers must exist before additional builders are spawned. The desired
-  number of builders is also capped by RCL: 2 at RCL1, 4 at RCL2 and 8 from
-  RCL3 onward.
+ - **Upgraders** – Capped by the number of open tiles within range&nbsp;3 of the
+   controller, minus active builders. They withdraw from a nearby container when
+   present and otherwise harvest directly. At least one upgrader is always
+   maintained.
+ - **Builders** – Limited to six per colony with a soft cap of two builders per
+   construction site. Builders grab energy from containers holding at least 500
+   energy, then dropped energy or harvest if needed. When no build or emergency
+   repair task is available they upgrade the controller as a fallback.
 
 The module updates `Memory.roleEval.lastRun` so a fallback task can throttle
 itself when CPU is scarce.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -60,6 +60,9 @@ taskRegistry.register('upgradeController', {
 | `deliverEnergy`  | `energyRequests` | 2               | Hauler delivery to a structure. |
 | `defendRoom`     | `hivemind.spawn` | 1               | Spawn defenders on hostiles.    |
 | `spawnBootstrap` | `spawnManager`   | 0               | Emergency worker when none exist. |
+| `acquireMiningData` | `roomManager` | 2 | Rescan room to rebuild mining positions. |
+| `buildSite` | `buildingManager` | 1 | Assign builders to a construction site. |
+| `repairEmergency` | `buildingManager` | 1 | Repair structures close to decay. |
 
 ### Registered Triggers
 
@@ -71,6 +74,9 @@ taskRegistry.register('upgradeController', {
 | `upgradeController` | event `roleUpdate` or energy surplus check    |
 | `defendRoom`      | event `hostilesDetected`                       |
 | `deliverEnergy`   | condition when structure free capacity > 0     |
+| `acquireMiningData` | event `missingMiningData`                     |
+| `buildSite` | event `newConstruction` |
+| `repairEmergency` | condition `structureDecayCritical` |
 
 Past executions can be inspected under `Memory.stats.taskLogs` when a module chooses to record them.
 

--- a/hive.roles.js
+++ b/hive.roles.js
@@ -80,14 +80,13 @@ const roles = {
     }
 
     // --- Upgrader calculation ---
-    let controllerContainers = [];
-    if (room.controller && room.controller.pos && room.controller.pos.findInRange) {
-      controllerContainers = room.controller.pos.findInRange(FIND_STRUCTURES, 3, {
-        filter: s => s.structureType === STRUCTURE_CONTAINER,
-      });
-    }
-    let desiredUpgraders = controllerContainers.length * 4;
-    if (desiredUpgraders === 0) desiredUpgraders = 1;
+    const availableSpots =
+      (Memory.rooms[roomName] && Memory.rooms[roomName].controllerUpgradeSpots) || 1;
+    const activeBuilders = _.filter(
+      Game.creeps,
+      c => c.memory.role === 'builder' && c.room.name === roomName,
+    ).length;
+    let desiredUpgraders = Math.max(1, availableSpots - activeBuilders);
     const liveUpgraders = _.filter(
       Game.creeps,
       c => c.memory.role === 'upgrader' && c.room.name === roomName,
@@ -115,30 +114,7 @@ const roles = {
 
     // --- Builder calculation ---
     const sites = room.find(FIND_CONSTRUCTION_SITES);
-    const haulersAlive = _.filter(
-      Game.creeps,
-      c => c.memory.role === 'hauler' && c.room.name === roomName,
-    ).length;
-    const queuedHaulers = spawnQueue.queue.filter(
-      q => q.memory.role === 'hauler' && q.room === roomName,
-    ).length;
-    const haulerTask = tasks.find(t => t.name === 'spawnHauler' && t.manager === 'spawnManager');
-    const haulerTaskAmount = haulerTask ? haulerTask.amount || 0 : 0;
-    const totalHaulers = haulersAlive + queuedHaulers + haulerTaskAmount;
-    const important = sites.filter(
-      s =>
-        s.structureType === STRUCTURE_EXTENSION ||
-        s.structureType === STRUCTURE_CONTAINER ||
-        s.structureType === STRUCTURE_ROAD,
-    );
-    const general = sites.length - important.length;
-    let desiredBuilders = 0;
-    if (important.length > 0) desiredBuilders = Math.min(12, important.length * 4);
-    else desiredBuilders = Math.min(12, general * 2);
-    if (totalHaulers < 2) desiredBuilders = 0;
-    const builderCaps = { 1: 2, 2: 4 };
-    const cap = builderCaps[room.controller.level] || 8;
-    desiredBuilders = Math.min(desiredBuilders, cap);
+    let desiredBuilders = Math.min(6, sites.length * 2);
     const liveBuilders = _.filter(
       Game.creeps,
       c => c.memory.role === 'builder' && c.room.name === roomName,

--- a/manager.memory.js
+++ b/manager.memory.js
@@ -60,6 +60,7 @@ const memoryManager = {
         miningPositions: {},
         reservedPositions: {},
         restrictedArea: [],
+        controllerUpgradeSpots: 0,
       };
     }
 

--- a/manager.room.js
+++ b/manager.room.js
@@ -92,14 +92,32 @@ const roomManager = {
       pos: { x: structure.pos.x, y: structure.pos.y },
     }));
 
-    const constructionSites = room.find(FIND_CONSTRUCTION_SITES);
-    Memory.rooms[room.name].constructionSites = constructionSites.map(
+  const constructionSites = room.find(FIND_CONSTRUCTION_SITES);
+  Memory.rooms[room.name].constructionSites = constructionSites.map(
       (site) => ({
         id: site.id,
         structureType: site.structureType,
         pos: { x: site.pos.x, y: site.pos.y },
       }),
     );
+
+    // Determine upgrade spots around the controller
+    if (room.controller) {
+      const terrain = room.getTerrain();
+      let count = 0;
+      for (let dx = -3; dx <= 3; dx++) {
+        for (let dy = -3; dy <= 3; dy++) {
+          const x = room.controller.pos.x + dx;
+          const y = room.controller.pos.y + dy;
+          if (x < 0 || x > 49 || y < 0 || y > 49) continue;
+          if (terrain.get(x, y) === TERRAIN_MASK_WALL) continue;
+          const structs = room.lookForAt(LOOK_STRUCTURES, x, y);
+          if (structs.some(s => OBSTACLE_OBJECT_TYPES.includes(s.structureType))) continue;
+          count++;
+        }
+      }
+      Memory.rooms[room.name].controllerUpgradeSpots = count;
+    }
   },
 
   // Other update functions remain unchanged

--- a/taskDefinitions.js
+++ b/taskDefinitions.js
@@ -23,6 +23,27 @@ taskRegistry.register('spawnBootstrap', {
   trigger: { type: 'condition', conditionFn: 'hivemind.spawn.bootstrap' },
 });
 
+taskRegistry.register('acquireMiningData', {
+  owner: 'roomManager',
+  priority: 2,
+  ttl: 20,
+  trigger: { type: 'event', eventName: 'missingMiningData' },
+});
+
+taskRegistry.register('buildSite', {
+  owner: 'buildingManager',
+  priority: 1,
+  ttl: 50,
+  trigger: { type: 'event', eventName: 'newConstruction' },
+});
+
+taskRegistry.register('repairEmergency', {
+  owner: 'buildingManager',
+  priority: 1,
+  ttl: 30,
+  trigger: { type: 'condition', conditionFn: 'structureDecayCritical' },
+});
+
 taskRegistry.register('upgradeController', {
   owner: 'hivemind.spawn',
   priority: 3,

--- a/test/allPurposeCollect.test.js
+++ b/test/allPurposeCollect.test.js
@@ -69,6 +69,9 @@ describe('allPurpose energy collection', function () {
     globals.resetGame();
     globals.resetMemory();
     Game.rooms['W1N1'] = { name: 'W1N1', find: () => [] };
+    Memory.rooms = {
+      W1N1: { miningPositions: { s1: { positions: { a: { x: 1, y: 1, roomName: 'W1N1', reserved: false } } } } },
+    };
   });
 
   it('moves to dropped energy when enough is available', function () {

--- a/test/allPurposeFallback.test.js
+++ b/test/allPurposeFallback.test.js
@@ -1,0 +1,77 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const htm = require('../manager.htm');
+const roleAllPurpose = require('../role.allPurpose');
+
+// Constants
+global.FIND_SOURCES = 1;
+global.FIND_MY_SPAWNS = 2;
+global.RESOURCE_ENERGY = 'energy';
+global.OK = 0;
+global.ERR_NOT_IN_RANGE = -9;
+
+// Simple RoomPosition mock
+global.RoomPosition = function(x, y, roomName) {
+  this.x = x;
+  this.y = y;
+  this.roomName = roomName;
+  this.isEqualTo = () => false;
+  this.isNearTo = () => false;
+  this.findClosestByRange = () => ({ id: 's1', pos: this });
+};
+
+function createCreep() {
+  return {
+    name: 'ap1',
+    room: Game.rooms['W1N1'],
+    store: { [RESOURCE_ENERGY]: 0, getFreeCapacity: () => 50 },
+    pos: {
+      x: 10,
+      y: 10,
+      roomName: 'W1N1',
+      findClosestByRange: () => ({ id: 's1', pos: { x: 5, y: 5, roomName: 'W1N1' } }),
+      isNearTo: () => false,
+      findClosestByPath: () => null,
+      isEqualTo: () => false,
+    },
+    travelTo: () => {},
+    harvest: () => OK,
+    transfer: () => OK,
+    memory: { working: false, desiredPosition: {} },
+  };
+}
+
+describe('allPurpose fallback', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory({ stats: { logs: [] } });
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: {},
+      find: type => {
+        if (type === FIND_SOURCES) return [{ id: 's1', pos: { x: 5, y: 5, roomName: 'W1N1' } }];
+        if (type === FIND_MY_SPAWNS) return [{ pos: { x: 1, y: 1, roomName: 'W1N1', getRangeTo: () => 1 } }];
+        return [];
+      },
+    };
+    Memory.rooms = { W1N1: {} }; // missing miningPositions
+    htm.init();
+  });
+
+  it('queues acquireMiningData when mining info missing', function() {
+    const creep = createCreep();
+    roleAllPurpose.run(creep);
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    expect(tasks[0].name).to.equal('acquireMiningData');
+    expect(creep.memory.fallbackReason).to.equal('missingMiningData');
+  });
+
+  it('clears fallback when data exists', function() {
+    Memory.rooms['W1N1'] = { miningPositions: { s1: { positions: { a: { x:1, y:1, roomName:'W1N1', reserved:false } } } } };
+    const creep = createCreep();
+    creep.memory.fallbackReason = 'missingMiningData';
+    roleAllPurpose.run(creep);
+    expect(creep.memory.fallbackReason).to.be.undefined;
+  });
+});

--- a/test/builderEnergy.test.js
+++ b/test/builderEnergy.test.js
@@ -29,11 +29,14 @@ function createCreep(name) {
       roomName: 'W1N1',
       getRangeTo: () => 5,
       findInRange: () => [],
+      findClosestByRange: () => ({ id: 's1', pos: { x: 1, y: 1, roomName: 'W1N1' } }),
+      isNearTo: () => false,
     },
     travelTo: () => {},
     build: () => OK,
     repair: () => OK,
     upgradeController: () => OK,
+    harvest: () => OK,
     memory: {},
   };
 }
@@ -48,9 +51,13 @@ describe('builder energy evaluation', function () {
 
   it('queues deliverEnergy when no nearby energy', function () {
     const creep = createCreep('b1');
+    let harvested = false;
+    creep.harvest = () => {
+      harvested = true;
+      return OK;
+    };
     roleBuilder.run(creep);
-    const tasks = Memory.htm.creeps['b1'].tasks;
-    expect(tasks[0].name).to.equal('deliverEnergy');
+    expect(harvested).to.be.true;
   });
 
   it('does not request energy if dropped energy nearby', function () {

--- a/test/builderMainTask.test.js
+++ b/test/builderMainTask.test.js
@@ -40,10 +40,13 @@ describe('builder retains mainTask while refueling', function() {
         roomName: 'W1N1',
         getRangeTo: () => 5,
         findInRange: () => [],
+        findClosestByRange: () => ({ id: 's1', pos: { x: 1, y: 1, roomName: 'W1N1' } }),
+        isNearTo: () => false,
       },
       travelTo: () => {},
       build: () => OK,
       upgradeController: () => OK,
+      harvest: () => OK,
     };
     roleBuilder.run(creep);
     expect(creep.memory.mainTask).to.equal('s1');

--- a/test/builderTaskMemory.test.js
+++ b/test/builderTaskMemory.test.js
@@ -38,16 +38,17 @@ describe('builder task memory', function () {
         roomName: 'W1N1',
         getRangeTo: () => 1,
         findInRange: () => [],
+        findClosestByRange: () => ({ id: 's1', pos: { x: 1, y: 1, roomName: 'W1N1' } }),
+        isNearTo: () => false,
       },
       travelTo: () => {},
       build: () => OK,
+      harvest: () => OK,
       memory: {},
     };
     roleBuilder.run(creep);
     expect(creep.memory.mainTask).to.deep.equal({ type: 'build', id: 's1' });
-    const tasks = Memory.htm.creeps['b1'].tasks;
-    const names = tasks.map(t => t.name);
-    expect(names).to.include('deliverEnergy');
+    expect(Memory.htm.creeps['b1']).to.be.undefined;
   });
 });
 

--- a/test/roleEvaluation.test.js
+++ b/test/roleEvaluation.test.js
@@ -90,6 +90,6 @@ describe('hive.roles evaluateRoom', function() {
     };
     roles.evaluateRoom(room);
     const limits = Memory.rooms['W1N1'].spawnLimits;
-    expect(limits.builders).to.equal(2);
+    expect(limits.builders).to.equal(4);
   });
 });

--- a/test/roomScanContainer.test.js
+++ b/test/roomScanContainer.test.js
@@ -8,6 +8,7 @@ global.FIND_SOURCES = 1;
 global.FIND_MY_SPAWNS = 2;
 global.FIND_STRUCTURES = 3;
 global.TERRAIN_MASK_WALL = 1;
+global.OBSTACLE_OBJECT_TYPES = [];
 
 global.PathFinder = {
   search(start, goal) {
@@ -31,7 +32,7 @@ describe('roomManager.scanRoom container placement', function() {
     global.TERRAIN_MASK_WALL = 1;
     Game.rooms['W1N1'] = {
       name: 'W1N1',
-      controller: { my: true },
+      controller: { my: true, pos: { x: 15, y: 15 } },
       find(type) {
         if (type === FIND_SOURCES) {
           return [{ id: 's1', pos: { x: 10, y: 10 } }];
@@ -47,6 +48,7 @@ describe('roomManager.scanRoom container placement', function() {
         if (type === FIND_STRUCTURES) return [];
         return [];
       },
+      lookForAt() { return []; },
       getTerrain() {
         return { get() { return 0; } };
       },


### PR DESCRIPTION
## Summary
- implement `acquireMiningData` task type
- add fallback logic in `role.allPurpose` when mining data is missing
- document new creep memory fields and HTM task
- adjust existing tests for new defaults and add fallback unit test
- refactor builder role and upgrader cap according to early game design

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68493fb3b1e483278ea8e45c13c6cd29