### PR TITLE
Adjust upgrader limits and spawn recovery logic

### DIFF
--- a/docs/roles.md
+++ b/docs/roles.md
@@ -12,14 +12,16 @@ Haulers remain governed by the energy demand module.
    `manager.dna` and capped at three creeps per source. Miners with at least five
    WORK parts automatically relocate onto the nearby container so they can empty
    the source without moving.
- - **Upgraders** – Capped by the number of open tiles within range&nbsp;3 of the
-   controller, minus active builders. They withdraw from a nearby container when
-   present and otherwise harvest directly. At least one upgrader is always
-   maintained.
+ - **Upgraders** – Up to four creeps based on open tiles within range&nbsp;3 of
+   the controller, minus active builders. They withdraw from a nearby container
+   or harvest directly and never request hauled energy. At least one upgrader is
+   always maintained.
  - **Builders** – Limited to six per colony with a soft cap of two builders per
-   construction site. Builders grab energy from containers holding at least 500
-   energy, then dropped energy or harvest if needed. When no build or emergency
-   repair task is available they upgrade the controller as a fallback.
+   construction site. Builder spawns are prioritised before upgraders so
+   construction continues smoothly. Builders grab energy from containers holding
+   at least 500 energy, then dropped energy or harvest if needed. When no build
+   or emergency repair task is available they upgrade the controller as a
+   fallback.
 
 The module updates `Memory.roleEval.lastRun` so a fallback task can throttle
 itself when CPU is scarce.

--- a/hive.roles.js
+++ b/hive.roles.js
@@ -86,7 +86,7 @@ const roles = {
       Game.creeps,
       c => c.memory.role === 'builder' && c.room.name === roomName,
     ).length;
-    let desiredUpgraders = Math.max(1, availableSpots - activeBuilders);
+    let desiredUpgraders = Math.min(4, Math.max(1, availableSpots - activeBuilders));
     const liveUpgraders = _.filter(
       Game.creeps,
       c => c.memory.role === 'upgrader' && c.room.name === roomName,
@@ -104,7 +104,7 @@ const roles = {
           roomName,
           'spawnUpgrader',
           { role: 'upgrader' },
-          3,
+          4,
           20,
           upgradersNeeded,
           'spawnManager',
@@ -132,7 +132,7 @@ const roles = {
           roomName,
           'spawnBuilder',
           { role: 'builder' },
-          4,
+          3,
           20,
           buildersNeeded,
           'spawnManager',

--- a/manager.hivemind.spawn.js
+++ b/manager.hivemind.spawn.js
@@ -229,6 +229,37 @@ const spawnModule = {
           spawnManager.spawnEmergencyCollector(spawns[0], room);
         }
       }
+
+      if (haulersAlive === 0) {
+        const spawns = room.find(FIND_MY_SPAWNS);
+        if (spawns.length > 0) {
+          const haulerCost = _.sum(
+            dna
+              .getBodyParts('hauler', room)
+              .map(p => BODYPART_COST[p])
+          );
+          const apBody = dna.getBodyParts('allPurpose', room, true);
+          const apCost = _.sum(apBody.map(p => BODYPART_COST[p]));
+          const apAlive = _.filter(
+            Game.creeps,
+            c => c.memory.role === 'allPurpose' && c.room.name === roomName,
+          ).length;
+          const apQueued = spawnQueue.queue.filter(
+            q => q.room === roomName && q.memory.role === 'allPurpose',
+          ).length;
+          const apSpawning = spawns.some(
+            s => s.memory && s.memory.currentSpawnRole === 'allPurpose',
+          );
+          if (
+            room.energyAvailable >= apCost &&
+            room.energyAvailable < haulerCost &&
+            apAlive + apQueued + (apSpawning ? 1 : 0) === 0
+          ) {
+            const spawnManager = require('./manager.spawn');
+            spawnManager.spawnAllPurpose(spawns[0], room, true);
+          }
+        }
+      }
     }
 
 

--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -12,8 +12,8 @@ const ROLE_PRIORITY = {
   allPurpose: 1,
   miner: 2,
   hauler: 3,
-  upgrader: 4,
-  builder: 5,
+  builder: 4,
+  upgrader: 5,
 };
 
 // Direction deltas for checking adjacent tiles around a spawn

--- a/role.upgrader.js
+++ b/role.upgrader.js
@@ -121,9 +121,6 @@ const roleUpgrader = {
         }
       } else {
         creep.travelTo(pos, { visualizePathStyle: { stroke: '#ffaa00' } });
-        if (!container || creep.pos.getRangeTo(container) > 1) {
-          requestEnergy(creep);
-        }
       }
       if (
         creep.store[RESOURCE_ENERGY] > 0 &&

--- a/test/energyRequest.test.js
+++ b/test/energyRequest.test.js
@@ -35,11 +35,10 @@ describe('energy request tasks', function() {
     global.STRUCTURE_CONTAINER = 'container';
   });
 
-  it('queues deliverEnergy when upgrader is empty', function() {
+  it('does not request hauled energy when empty', function() {
     const creep = createCreep('u1');
     roleUpgrader.run(creep);
-    const tasks = Memory.htm.creeps['u1'].tasks;
-    expect(tasks[0].name).to.equal('deliverEnergy');
+    expect(Memory.htm.creeps['u1']).to.be.undefined;
   });
 
   it('withdraws energy from container before requesting delivery', function() {

--- a/test/roleEvaluation.test.js
+++ b/test/roleEvaluation.test.js
@@ -92,4 +92,12 @@ describe('hive.roles evaluateRoom', function() {
     const limits = Memory.rooms['W1N1'].spawnLimits;
     expect(limits.builders).to.equal(4);
   });
+
+  it('limits upgraders to four', function() {
+    const room = Game.rooms['W1N1'];
+    Memory.rooms['W1N1'].controllerUpgradeSpots = 8;
+    roles.evaluateRoom(room);
+    const limits = Memory.rooms['W1N1'].spawnLimits;
+    expect(limits.upgraders).to.equal(4);
+  });
 });


### PR DESCRIPTION
## Summary
- prioritize builders over upgraders in spawn queue
- cap upgraders at four and update role evaluation
- spawn minimal allPurpose when no haulers can be produced
- remove upgrader energy requests
- document new limits and priorities
- update tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849813c59c08327bd5569c0780b1f52