### PR TITLE
Implement hauler lifecycle prediction

### DIFF
--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -34,7 +34,12 @@ its queue is empty.
   recover. The module enforces a strict initial order at RCL1: one
   allPurpose creep, two miners and two haulers must be accounted for before an
   upgrader is queued.
- - **demand** – Tracks energy deliveries. When the combined
+- **lifecycle** – Runs every 25 ticks via the scheduler to queue miner replacements before the current
+  miner expires using precomputed travel times. A second module predicts hauler
+  replacements using average roundtrip durations and only queues a new hauler
+  when demand persists and no other replacement is scheduled for the same
+  route.
+- **demand** – Tracks energy deliveries. When the combined
   `demandRate` for requesters exceeds the current `supplyRate` the Hive
   automatically queues enough haulers to close the gap. Delivery statistics are
   stored per-room under `Memory.demand.rooms` along with aggregate `totals`

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -71,6 +71,8 @@ The main loop registers several core jobs which drive the colony:
 | `htmRun`             | 1 tick         | `htm`              | Processes HTM task queues. |
 | `consoleDisplay`     | 5 ticks        | `console.console`  | Prints stats and logs to console. |
 | `purgeLogs`          | 250 ticks      | `memoryManager`    | Clears aggregated log counts. |
+| `predictMinerLifecycles` | 25 ticks | `lifecyclePredictor` | Queues miner replacements before death. |
+| `predictHaulerLifecycle` | 25 ticks | `haulerLifecycle` | Queues hauler replacements before death. |
 | `verifyMiningReservations` | 10 ticks | `memoryManager`    | Frees reserved mining spots from dead creeps. |
 | `htmCleanup`         | 50 ticks       | `htm`              | Removes memory for dead creeps. |
 | `showScheduled`      | 50 ticks       | `scheduler`        | Optional debug output of task list. |

--- a/haulerLifecycle.js
+++ b/haulerLifecycle.js
@@ -1,0 +1,102 @@
+const spawnQueue = require('./manager.spawnQueue');
+const spawnManager = require('./manager.spawn');
+const _ = require('lodash');
+
+const BUFFER_TICKS = 12;
+
+function recordSpawnTiming(creep) {
+  if (
+    creep.memory.spawnedBy === 'lifecyclePredictor' &&
+    creep.memory.originDeathTick &&
+    !creep.memory.spawnTimingEvaluated
+  ) {
+    if (!Memory.stats) Memory.stats = {};
+    if (!Memory.stats.haulerSpawnTiming) {
+      Memory.stats.haulerSpawnTiming = {
+        late: 0,
+        early: 0,
+        perfect: 0,
+        history: [],
+      };
+    }
+    const stats = Memory.stats.haulerSpawnTiming;
+    const delta = creep.memory.originDeathTick - Game.time;
+    if (delta < -BUFFER_TICKS) stats.late++;
+    else if (delta > BUFFER_TICKS) stats.early++;
+    else stats.perfect++;
+    stats.history.push(delta);
+    if (stats.history.length > 10) stats.history.shift();
+    creep.memory.spawnTimingEvaluated = true;
+  }
+}
+
+const lifecycle = {
+  runRoom(room) {
+    const spawns = room.find(FIND_MY_SPAWNS);
+    if (spawns.length === 0) return;
+    const spawn = spawns[0];
+
+    const haulers = _.filter(
+      Game.creeps,
+      (c) => c.memory.role === 'hauler' && c.room.name === room.name,
+    );
+    for (const hauler of haulers) {
+      recordSpawnTiming(hauler);
+      if (!hauler.ticksToLive || !hauler.memory.assignment) continue;
+      const routeId = hauler.memory.assignment.routeId;
+      const routeMem = _.get(Memory, ['demand', 'routes', routeId]);
+      if (!routeMem || routeMem.avgRoundTrip === undefined) continue;
+      const demandAmount = _.get(routeMem, ['totals', 'demand'], 0);
+      if (demandAmount <= 0) continue;
+      const avgRoundTrip = routeMem.avgRoundTrip || 0;
+      const spawnTime = hauler.body.length * CREEP_SPAWN_TIME;
+      const leadTime = spawnTime + avgRoundTrip + BUFFER_TICKS;
+
+      if (hauler.ticksToLive > leadTime) continue;
+
+      const queued = spawnQueue.queue.some(
+        (q) => q.category === 'hauler' && q.assignment && q.assignment.routeId === routeId,
+      );
+      if (queued) continue;
+
+      const other = _.find(
+        Game.creeps,
+        (c) =>
+          c.name !== hauler.name &&
+          c.memory.role === 'hauler' &&
+          c.memory.assignment &&
+          c.memory.assignment.routeId === routeId,
+      );
+      if (other) continue;
+
+      const memoryClone = JSON.parse(JSON.stringify(hauler.memory));
+      memoryClone.spawnedBy = 'lifecyclePredictor';
+      memoryClone.originCreep = hauler.name;
+      memoryClone.originDeathTick = Game.time + hauler.ticksToLive;
+
+      spawnQueue.addToQueue(
+        'hauler',
+        room.name,
+        hauler.body.map((p) => (p.type ? p.type : p)),
+        memoryClone,
+        spawn.id,
+        0,
+        spawnManager.PRIORITY_HIGH,
+      );
+      const entry = spawnQueue.queue[spawnQueue.queue.length - 1];
+      entry.origin = 'lifecyclePredictor';
+      entry.assignment = memoryClone.assignment;
+    }
+  },
+
+  run() {
+    for (const roomName in Game.rooms) {
+      const room = Game.rooms[roomName];
+      if (room.controller && room.controller.my) {
+        this.runRoom(room);
+      }
+    }
+  },
+};
+
+module.exports = lifecycle;

--- a/hiveMind.lifecycle.js
+++ b/hiveMind.lifecycle.js
@@ -1,0 +1,107 @@
+const spawnQueue = require('./manager.spawnQueue');
+const spawnManager = require('./manager.spawn');
+const _ = require('lodash');
+
+const BUFFER_TICKS = 10;
+
+const lifecycle = {
+  runRoom(room) {
+    const spawns = room.find(FIND_MY_SPAWNS);
+    if (spawns.length === 0) return;
+    const spawn = spawns[0];
+
+    const miners = _.filter(
+      Game.creeps,
+      (c) => c.memory.role === 'miner' && c.room.name === room.name,
+    );
+    for (const miner of miners) {
+      if (!miner.ticksToLive || !miner.memory.miningPosition) continue;
+      const sourceId = miner.memory.sourceId || miner.memory.source;
+      const moveTime = _.get(
+        Memory,
+        ['rooms', room.name, 'miningPositions', sourceId, 'distanceFromSpawn'],
+        miner.memory.distanceToSpawn || 0,
+      );
+      const spawnTime = miner.body.length * CREEP_SPAWN_TIME;
+      const leadTime = spawnTime + moveTime + BUFFER_TICKS;
+
+      if (miner.ticksToLive > leadTime) continue;
+
+      const pos = miner.memory.miningPosition;
+      if (!pos || pos.x === undefined || pos.y === undefined || !pos.roomName)
+        continue;
+
+      const queued = spawnQueue.queue.some(
+        (q) =>
+          q.category === 'miner' &&
+          ((q.assignment &&
+            q.assignment.pos &&
+            q.assignment.pos.x === pos.x &&
+            q.assignment.pos.y === pos.y &&
+            q.assignment.pos.roomName === pos.roomName) ||
+            (q.memory &&
+              q.memory.miningPosition &&
+              q.memory.miningPosition.x === pos.x &&
+              q.memory.miningPosition.y === pos.y &&
+              q.memory.miningPosition.roomName === pos.roomName)),
+      );
+      if (queued) continue;
+
+      const other = _.find(
+        Game.creeps,
+        (c) =>
+          c.name !== miner.name &&
+          c.memory.role === 'miner' &&
+          c.memory.miningPosition &&
+          c.memory.miningPosition.x === pos.x &&
+          c.memory.miningPosition.y === pos.y &&
+          c.memory.miningPosition.roomName === pos.roomName &&
+          c.ticksToLive &&
+          c.ticksToLive > leadTime,
+      );
+      if (other) continue;
+
+      const memoryClone = JSON.parse(JSON.stringify(miner.memory));
+      memoryClone.spawnedBy = 'lifecyclePredictor';
+      memoryClone.originCreep = miner.name;
+
+      spawnQueue.addToQueue(
+        'miner',
+        room.name,
+        miner.body.map((p) => (p.type ? p.type : p)),
+        memoryClone,
+        spawn.id,
+        0,
+        spawnManager.PRIORITY_HIGH,
+      );
+      const entry = spawnQueue.queue[spawnQueue.queue.length - 1];
+      entry.origin = 'lifecyclePredictor';
+      entry.assignment = { sourceId, pos };
+
+      if (!Memory.stats) Memory.stats = {};
+      if (!Memory.stats.lifecyclePrediction)
+        Memory.stats.lifecyclePrediction = {};
+      if (!Memory.stats.lifecyclePrediction.miner) {
+        Memory.stats.lifecyclePrediction.miner = {
+          replacedOnTime: 0,
+          replacedLate: 0,
+          energyMissedEstimate: 0,
+        };
+      }
+      const stats = Memory.stats.lifecyclePrediction.miner;
+      if (miner.ticksToLive <= moveTime + BUFFER_TICKS) stats.replacedLate++;
+      else stats.replacedOnTime++;
+    }
+  },
+
+  run() {
+    for (const roomName in Game.rooms) {
+      const room = Game.rooms[roomName];
+      if (room.controller && room.controller.my) {
+        this.runRoom(room);
+      }
+    }
+  },
+};
+
+module.exports = lifecycle;

--- a/main.js
+++ b/main.js
@@ -21,6 +21,8 @@ const introspect = require('./debug.introspection');
 require('./taskDefinitions');
 const htm = require("manager.htm");
 const hivemind = require("manager.hivemind");
+const lifecycle = require('./hiveMind.lifecycle');
+const haulerLifecycle = require('./haulerLifecycle');
 const movementUtils = require("./utils.movement");
 
 const energyDemand = require("./manager.hivemind.demand");
@@ -180,6 +182,16 @@ scheduler.addTask("buildInfrastructure", 0, () => {
     buildingManager.buildInfrastructure(room);
   }
 }); // @codex-owner buildingManager @codex-trigger {"type":"interval","interval":0}
+
+// Lifecycle-based miner replacement
+scheduler.addTask('predictMinerLifecycles', 25, () => {
+  lifecycle.run();
+}); // @codex-owner lifecyclePredictor @codex-trigger {"type":"interval","interval":25}
+
+// Lifecycle-based hauler replacement
+scheduler.addTask('predictHaulerLifecycle', 25, () => {
+  haulerLifecycle.run();
+}); // @codex-owner haulerLifecycle @codex-trigger {"type":"interval","interval":25}
 
 // Decision making layer feeding tasks into HTM
 scheduler.addTask("hivemind", 1, () => {

--- a/manager.room.js
+++ b/manager.room.js
@@ -32,6 +32,7 @@ const roomManager = {
 
       // Determine container spot along the path to the spawn
       let pathPosition = null;
+      let distanceFromSpawn = 0;
       if (spawn) {
         const result = PathFinder.search(
           spawn.pos,
@@ -42,6 +43,7 @@ const roomManager = {
           const step = result.path[result.path.length - 1];
           pathPosition = { x: step.x, y: step.y };
         }
+        distanceFromSpawn = result.path ? result.path.length : 0;
       }
 
       potential.sort((a, b) =>
@@ -80,6 +82,7 @@ const roomManager = {
       Memory.rooms[room.name].miningPositions[source.id] = {
         x: sourcePos.x,
         y: sourcePos.y,
+        distanceFromSpawn,
         positions,
       };
     });

--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -16,6 +16,9 @@ const ROLE_PRIORITY = {
   upgrader: 5,
 };
 
+// Exportable priority constants for external modules
+const PRIORITY_HIGH = ROLE_PRIORITY.miner;
+
 // Direction deltas for checking adjacent tiles around a spawn
 const directionDelta = {
   [TOP]: { x: 0, y: -1 },
@@ -189,9 +192,12 @@ const spawnManager = {
       );
 
       if (miningPositionAssigned) {
-        const distanceToSpawn = spawn.pos.getRangeTo(
-          Game.getObjectById(source.id).pos,
-        );
+        const sourceMem =
+          Memory.rooms[room.name].miningPositions[source.id] || {};
+        const distanceToSpawn =
+          sourceMem.distanceFromSpawn !== undefined
+            ? sourceMem.distanceFromSpawn
+            : spawn.pos.getRangeTo(Game.getObjectById(source.id).pos);
         const energyProducedPerTick = energyPerTick;
         const collectionTicks = calculateCollectionTicks(energyProducedPerTick);
 
@@ -646,3 +652,5 @@ const spawnManager = {
 };
 
 module.exports = spawnManager;
+module.exports.PRIORITY_HIGH = PRIORITY_HIGH;
+module.exports.ROLE_PRIORITY = ROLE_PRIORITY;

--- a/test/haulerLifecycle.test.js
+++ b/test/haulerLifecycle.test.js
@@ -1,0 +1,97 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const statsConsole = require('../console.console');
+
+global._ = require('lodash');
+global.CARRY = 'carry';
+global.MOVE = 'move';
+global.TOP = 1;
+global.TOP_RIGHT = 2;
+global.RIGHT = 3;
+global.BOTTOM_RIGHT = 4;
+global.BOTTOM = 5;
+global.BOTTOM_LEFT = 6;
+global.LEFT = 7;
+global.TOP_LEFT = 8;
+global.CREEP_SPAWN_TIME = 3;
+
+const haulerLifecycle = require('../haulerLifecycle');
+const spawnQueue = require('../manager.spawnQueue');
+const spawnManager = require('../manager.spawn');
+global.FIND_MY_SPAWNS = 1;
+
+describe('hauler lifecycle predictor', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawnQueue.queue = [];
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find: type => {
+        if (type === FIND_MY_SPAWNS) {
+          return [{ id: 's1', pos: { getRangeTo: () => 0 }, room: { name: 'W1N1' } }];
+        }
+        return [];
+      },
+    };
+    Memory.demand = { routes: { r1: { avgRoundTrip: 10, activeHaulers: [], totals: { demand: 50 } } } };
+    Game.creeps = {
+      hauler1: {
+        name: 'hauler1',
+        room: Game.rooms['W1N1'],
+        body: [CARRY, MOVE],
+        ticksToLive: 25,
+        memory: {
+          role: 'hauler',
+          assignment: { routeId: 'r1', sourceId: 'src', destId: 'dest' },
+        },
+      },
+    };
+  });
+
+  it('queues replacement when ttl low and demand exists', function() {
+    haulerLifecycle.runRoom(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(1);
+    const entry = spawnQueue.queue[0];
+    expect(entry.origin).to.equal('lifecyclePredictor');
+    expect(entry.memory.originCreep).to.equal('hauler1');
+    expect(entry.priority).to.equal(spawnManager.PRIORITY_HIGH);
+  });
+
+  it('skips when replacement already queued', function() {
+    spawnQueue.queue.push({ category: 'hauler', assignment: { routeId: 'r1' }, memory: { assignment: { routeId: 'r1' } } });
+    haulerLifecycle.runRoom(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(1);
+  });
+
+  it('skips when demand is zero', function() {
+    Memory.demand.routes.r1.totals = { demand: 0 };
+    haulerLifecycle.runRoom(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(0);
+  });
+
+  it('skips when another hauler alive', function() {
+    Game.creeps.h2 = {
+      name: 'h2',
+      room: Game.rooms['W1N1'],
+      body: [CARRY, MOVE],
+      ticksToLive: 100,
+      memory: { role: 'hauler', assignment: { routeId: 'r1' } },
+    };
+    haulerLifecycle.runRoom(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(0);
+  });
+
+  it('classifies spawn timing', function() {
+    Game.time = 100;
+    haulerLifecycle.runRoom(Game.rooms['W1N1']);
+    const mem = spawnQueue.queue[0].memory;
+    spawnQueue.queue = [];
+    Game.time = 120;
+    Game.creeps.h2 = { name: 'h2', room: Game.rooms['W1N1'], body: [CARRY, MOVE], memory: mem, ticksToLive: 150 };
+    haulerLifecycle.runRoom(Game.rooms['W1N1']);
+    expect(Memory.stats.haulerSpawnTiming.perfect).to.equal(1);
+  });
+});

--- a/test/lifecyclePrediction.test.js
+++ b/test/lifecyclePrediction.test.js
@@ -1,0 +1,93 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const lifecycle = require('../hiveMind.lifecycle');
+const spawnQueue = require('../manager.spawnQueue');
+const spawnManager = require('../manager.spawn');
+
+global._ = require('lodash');
+
+global.WORK = 'work';
+global.MOVE = 'move';
+global.CREEP_SPAWN_TIME = 3;
+global.FIND_MY_SPAWNS = 1;
+
+
+describe('miner lifecycle predictor', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawnQueue.queue = [];
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find: type => {
+        if (type === FIND_MY_SPAWNS) {
+          return [{ id: 's1', pos: { getRangeTo: () => 0 }, room: { name: 'W1N1' } }];
+        }
+        return [];
+      },
+    };
+    Memory.rooms = {
+      W1N1: {
+        miningPositions: {
+          src1: { distanceFromSpawn: 10 },
+        },
+      },
+    };
+    Game.creeps = {
+      miner1: {
+        name: 'miner1',
+        room: Game.rooms['W1N1'],
+        body: [WORK, WORK, WORK, WORK, WORK, MOVE],
+        ticksToLive: 30,
+        memory: {
+          role: 'miner',
+          miningPosition: { x: 10, y: 10, roomName: 'W1N1' },
+          distanceToSpawn: 5,
+          sourceId: 'src1',
+        },
+      },
+    };
+  });
+
+  it('queues replacement when ttl below threshold', function() {
+    lifecycle.runRoom(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(1);
+    const entry = spawnQueue.queue[0];
+    expect(entry.origin).to.equal('lifecyclePredictor');
+    expect(entry.memory.originCreep).to.equal('miner1');
+    expect(entry.priority).to.equal(spawnManager.PRIORITY_HIGH);
+  });
+
+  it('uses travel time from room memory', function() {
+    Game.creeps.miner1.ticksToLive = 34;
+    lifecycle.runRoom(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(1);
+  });
+
+  it('skips when queued already', function() {
+    spawnQueue.queue.push({
+      category: 'miner',
+      assignment: { pos: { x: 10, y: 10, roomName: 'W1N1' } },
+      memory: { miningPosition: { x: 10, y: 10, roomName: 'W1N1' } },
+    });
+    lifecycle.runRoom(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(1);
+  });
+
+  it('skips when another miner active', function() {
+    Game.creeps.miner2 = {
+      name: 'miner2',
+      room: Game.rooms['W1N1'],
+      body: [WORK],
+      ticksToLive: 100,
+      memory: {
+        role: 'miner',
+        miningPosition: { x: 10, y: 10, roomName: 'W1N1' },
+      },
+    };
+    lifecycle.runRoom(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Summary
- expand lifecycle docs and memory schema
- schedule hauler lifecycle predictor via scheduler
- implement haulerLifecycle.js for proactive hauler replacement
- track roundtrip metrics and spawn timing
- add unit tests for hauler lifecycle predictions
- enforce demand-aware spawning and duplicate queue protection

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a717028c48327ad63862ad9d14abc