### PR TITLE
Integrate ghost layer into extension planning

### DIFF
--- a/docs/visuals.md
+++ b/docs/visuals.md
@@ -8,6 +8,11 @@ Enable it by setting `Memory.settings.showLayoutOverlay` to `true`.
 `RoomVisual.js` is loaded in `main.js` to extend the prototype with
 `.structure` and related helpers used for ghost drawings.
 
+When the building manager plans extensions via `layoutPlanner`,
+their stamp is stored in `room.memory.baseLayout`. The ghost layer
+reads from this memory so you can preview extension locations before
+construction sites are placed.
+
 Colors indicate build status:
 
 | Color       | Meaning                        |

--- a/manager.building.js
+++ b/manager.building.js
@@ -259,80 +259,13 @@ const buildingManager = {
   },
 
   buildExtensions: function (room) {
-    const spawn = room.find(FIND_MY_SPAWNS)[0];
-    if (!spawn) return;
-
-    const extensionSites = room.find(FIND_CONSTRUCTION_SITES, {
-      filter: (site) => site.structureType === STRUCTURE_EXTENSION,
-    });
-
-    const extensions = room.find(FIND_MY_STRUCTURES, {
-      filter: (structure) => structure.structureType === STRUCTURE_EXTENSION,
-    });
-
-    const maxExtensions =
-      CONTROLLER_STRUCTURES[STRUCTURE_EXTENSION][room.controller.level] || 0;
-    let remaining = maxExtensions - (extensions.length + extensionSites.length);
-    if (remaining <= 0) return;
-
-    if (!room.memory.extensionCenters) room.memory.extensionCenters = [];
-
-    const centers = [
-      { x: spawn.pos.x - 2, y: spawn.pos.y - 2 },
-      { x: spawn.pos.x + 2, y: spawn.pos.y - 2 },
-      { x: spawn.pos.x - 2, y: spawn.pos.y + 2 },
-      { x: spawn.pos.x + 2, y: spawn.pos.y + 2 },
-    ];
-
-    const terrain = room.getTerrain();
-
-    for (const center of centers) {
-      if (remaining <= 0) break;
-      const key = `${center.x},${center.y}`;
-      if (room.memory.extensionCenters.indexOf(key) !== -1) continue;
-
-      const stamp = [
-        { x: center.x, y: center.y - 1 },
-        { x: center.x - 1, y: center.y },
-        { x: center.x, y: center.y },
-        { x: center.x + 1, y: center.y },
-        { x: center.x, y: center.y + 1 },
-      ];
-
-      let buildable = true;
-      for (const p of stamp) {
-        if (p.x < 1 || p.x > 48 || p.y < 1 || p.y > 48) {
-          buildable = false;
-          break;
-        }
-        if (terrain.get(p.x, p.y) === TERRAIN_MASK_WALL) {
-          buildable = false;
-          break;
-        }
-        if (room.lookForAt(LOOK_STRUCTURES, p.x, p.y).length > 0) {
-          buildable = false;
-          break;
-        }
-        if (room.lookForAt(LOOK_CONSTRUCTION_SITES, p.x, p.y).length > 0) {
-          buildable = false;
-          break;
-        }
-      }
-      if (!buildable) continue;
-
-      let created = false;
-      for (const p of stamp) {
-        if (remaining <= 0) break;
-        const result = room.createConstructionSite(p.x, p.y, STRUCTURE_EXTENSION);
-        if (result === OK) {
-          statsConsole.log(`Queued extension construction at ${p.x},${p.y}`, 6);
-          remaining--;
-          created = true;
-        }
-      }
-      if (created) {
-        room.memory.extensionCenters.push(key);
-      }
+    // Ensure the base layout and extension stamp exist so the
+    // layoutVisualizer can render ghost extensions. Actual
+    // construction sites are created by executeLayout().
+    if (!room.memory.baseLayout ||
+        !room.memory.baseLayout.stamps ||
+        !room.memory.baseLayout.stamps[STRUCTURE_EXTENSION]) {
+      layoutPlanner.planBaseLayout(room);
     }
   },
 

--- a/test/extensionStamp.test.js
+++ b/test/extensionStamp.test.js
@@ -18,11 +18,12 @@ describe('extension stamp placement', function() {
     globals.resetGame();
     globals.resetMemory();
     Memory.stats = { logs: [] };
+    Memory.rooms = { W1N1: {} };
     const terrain = { get: () => 0 };
     const spawn = { pos: { x:4, y:4, roomName:'W1N1' } };
     Game.rooms['W1N1'] = {
       name: 'W1N1',
-      controller: { level:2 },
+      controller: { level:2, my: true },
       find: type => {
         if (type === FIND_MY_SPAWNS) return [spawn];
         if (type === FIND_MY_STRUCTURES) return [];
@@ -32,19 +33,19 @@ describe('extension stamp placement', function() {
       lookForAt: () => [],
       getTerrain: () => terrain,
       createConstructionSite: (x,y,type) => { created.push({x,y,type}); return OK; },
-      memory: {},
+      memory: Memory.rooms['W1N1'],
     };
     created = [];
   });
 
   let created;
 
-  it('creates plus-shaped extension stamp', function() {
+  it('stores extension stamp in room memory', function() {
     const room = Game.rooms['W1N1'];
     building.buildExtensions(room);
-    expect(created).to.have.lengthOf(5);
-    const coords = created.map(p => `${p.x},${p.y}`);
-    expect(coords).to.have.members(['2,1','1,2','2,2','3,2','2,3']);
-    expect(room.memory.extensionCenters).to.include('2,2');
+    expect(created).to.have.lengthOf(0);
+    expect(room.memory.baseLayout).to.exist;
+    const ext = room.memory.baseLayout.stamps[STRUCTURE_EXTENSION];
+    expect(ext).to.have.lengthOf(5);
   });
 });


### PR DESCRIPTION
## Summary
- ensure buildingManager relies on layoutPlanner for extensions
- update extension stamp test to check baseLayout usage
- document ghost layer behavior in visuals doc

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a81eafac083278061ead39aa44cf2