### PR TITLE
Implement remote mining metrics and retries

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -214,6 +214,7 @@ Memory.settings = {
   enableVisuals: true,
   showTaskList: false,
   energyLogs: false,
+  debugHiveGaze: false,
 };
 ```
 
@@ -273,6 +274,28 @@ Memory.stats.haulerSpawnTiming = {
 };
 ```
 
+### Expansion Vision Timestamp
+
+@codex-owner hiveGaze
+@codex-path Memory.hive.expansionVisionLastCheck
+
+Last game tick when HiveGaze evaluated exits and queued scout tasks.
+
+### Mining Route Cache
+
+@codex-owner hiveGaze
+@codex-path Memory.rooms[roomName].miningRoutes
+
+Each source stores the path length from the spawn used by lifecycle
+prediction and remote logistics.
+
+```javascript
+Memory.rooms['W1N1'].miningRoutes['src1'] = {
+  pathLength: 15,
+  lastCalculated: 12345
+};
+```
+
 ### Creep Fallback State
 
 @codex-owner role.allPurpose
@@ -285,6 +308,58 @@ room data is missing. These fields are cleared once normal behaviour resumes.
 creep.memory.fallbackReason = 'missingMiningData';
 creep.memory.fallbackSince = Game.time;
 ```
+
+### Scout Retirement Flag
+
+@codex-owner role.scout
+@codex-path creep.memory.retiring
+
+Indicates a scout has re-queued its task due to low TTL and is
+returning to base for recycling.
+
+```javascript
+creep.memory.retiring = true;
+```
+
+### Scout Cooldown
+
+@codex-owner hiveGaze
+@codex-path Memory.rooms[roomName].scoutCooldownUntil
+
+Rooms that have failed scouting multiple times will be skipped until this
+timestamp. The cooldown prevents endless re-queuing of unreachable scout tasks.
+
+### Remote Scoring
+
+@codex-owner hiveGaze
+@codex-path Memory.rooms[room].remoteScore
+@codex-path Memory.rooms[room].sources[sourceId].score
+@codex-path Memory.rooms[room].sources[sourceId].assignedPosition
+@codex-path Memory.rooms[room].sources[sourceId].reservedBy
+@codex-path Memory.hive.expansionTarget
+
+Scores computed for remote mining targets are stored per room and per source.
+`assignedPosition` and `reservedBy` track remote miner reservations. The room
+with the highest `remoteScore` is kept under `Memory.hive.expansionTarget`.
+
+### Remote Room Tracking
+
+@codex-owner hiveGaze
+@codex-path Memory.hive.claimedRemotes
+
+Active remote rooms currently mined or reserved by the hive. Entries are added
+when a remote miner is alive or a controller reservation exceeds 1000 ticks.
+Rooms are removed once no miner is present and reservation time drops below
+1000 ticks.
+
+@codex-path Memory.rooms[room].reserveAttempts
+
+Number of failed reservation attempts for a room. Resets on success.
+
+@codex-path Memory.stats.remoteRooms[roomName]
+
+Statistics for remote operations including miner and reservist spawn counts,
+successes, and failures.
 
 ### Controller Upgrade Spots
 

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -28,6 +28,10 @@ Haulers remain governed by the energy demand module.
   Haulers also relocate to an open tile near the spawn after depositing when
   the drop location is within the restricted area so they never idle on those
   reserved spots.
+- **Remote Miners** – Travel to pre-assigned coordinates in remote rooms and
+  harvest until death. They keep mining positions reserved via memory.
+- **Reservists** – Lightweight creeps that reserve a remote controller and sign
+  it with a Tyranid-themed message before expiring.
 
 The module updates `Memory.roleEval.lastRun` so a fallback task can throttle
 itself when CPU is scarce.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,6 +11,7 @@ Memory.settings = {
   showTaskList: false,      // print scheduled tasks periodically
   energyLogs: false,        // enable energy request & demand logging
   showLayoutOverlay: false, // draw planned structures
+  debugHiveGaze: false,     // verbose scout & hiveGaze logging
 };
 ```
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -64,6 +64,9 @@ taskRegistry.register('upgradeController', {
 | `buildSite` | `buildingManager` | 1 | Assign builders to a construction site. |
 | `repairEmergency` | `buildingManager` | 1 | Repair structures close to decay. |
 | `BUILD_LAYOUT_PART` | `buildingManager` | 1 | Construct next piece of the base layout. | @codex-owner buildingManager
+| `REMOTE_SCORE_ROOM` | `hiveGaze` | 4 | Evaluate remote sources and assign scores. |
+| `REMOTE_MINER_INIT` | `hiveGaze` | 2 | Reserve a remote mining spot and spawn a miner. |
+| `RESERVE_REMOTE_ROOM` | `hiveGaze` | 3 | Spawn a reservist to secure the controller. Tasks may be requeued automatically with origin `autoRetry`. |
 
 ### Registered Triggers
 

--- a/manager.hiveGaze.js
+++ b/manager.hiveGaze.js
@@ -1,0 +1,288 @@
+const htm = require('./manager.htm');
+const spawnQueue = require('./manager.spawnQueue');
+const spawnManager = require('./manager.spawn');
+const _ = require('lodash');
+const statsConsole = require('console.console');
+const { getRandomTyranidQuote } = require('./utils.quotes');
+
+/**
+ * HiveGaze explores exits and queues scout tasks.
+ * @codex-owner hiveGaze
+ */
+function scoreTerrain(roomName) {
+  const terrain = Game.map.getRoomTerrain(roomName);
+  let open = 0;
+  for (let x = 0; x < 50; x++) {
+    for (let y = 0; y < 50; y++) {
+      if (terrain.get(x, y) !== TERRAIN_MASK_WALL) open++;
+    }
+  }
+  return open;
+}
+
+function cacheMiningRoutes(room) {
+  const spawn = room.find(FIND_MY_SPAWNS)[0];
+  if (!spawn) return;
+  if (!Memory.rooms[room.name].miningRoutes)
+    Memory.rooms[room.name].miningRoutes = {};
+  const sources = room.find(FIND_SOURCES);
+  for (const source of sources) {
+    const result = PathFinder.search(spawn.pos, { pos: source.pos, range: 1 }, {
+      swampCost: 2,
+      plainCost: 2,
+      ignoreCreeps: true,
+    });
+    Memory.rooms[room.name].miningRoutes[source.id] = {
+      pathLength: result.path.length,
+      lastCalculated: Game.time,
+    };
+  }
+}
+
+const hiveGaze = {
+  scoreTerrain,
+
+  /** Evaluate exits and queue scouting tasks
+   *  @codex-owner hiveGaze
+   */
+  evaluateExpansionVision() {
+    htm.init();
+    if (!Memory.hive) Memory.hive = { clusters: {} };
+    if (!Memory.rooms) Memory.rooms = {};
+    for (const roomName in Game.rooms) {
+      const room = Game.rooms[roomName];
+      if (!room.controller || !room.controller.my) continue;
+      cacheMiningRoutes(room);
+      const exits = Game.map.describeExits(roomName) || {};
+      for (const dir in exits) {
+        const target = exits[dir];
+        const mem = Memory.rooms[target];
+        if (mem && mem.scoutCooldownUntil && mem.scoutCooldownUntil > Game.time) {
+          continue; // skip rooms on cooldown
+        }
+        const last = mem && mem.lastScouted ? mem.lastScouted : 0;
+        if (!mem || Game.time - last > 15000) {
+          htm.addColonyTask(
+            roomName,
+            'SCOUT_ROOM',
+            { roomName: target },
+            5,
+            500,
+            1,
+            'hiveGaze',
+            { module: 'hiveGaze', createdBy: 'evaluateExpansionVision', tickCreated: Game.time },
+          );
+        }
+      }
+    }
+    Memory.hive.expansionVisionLastCheck = Game.time;
+  },
+
+  /** Ensure a scout exists when tasks remain unclaimed
+   *  @codex-owner hiveGaze
+   */
+  manageScouts() {
+    const scouts = _.filter(Game.creeps, c => c.memory.role === 'scout');
+    const tasks = [];
+    if (Memory.htm && Memory.htm.colonies) {
+      for (const col in Memory.htm.colonies) {
+        const container = Memory.htm.colonies[col];
+        if (!container.tasks) continue;
+        for (const t of container.tasks) {
+          if (t.name === 'SCOUT_ROOM') tasks.push({ colony: col, task: t });
+        }
+      }
+    }
+    const queued = spawnQueue.queue.some(q => q.category === 'scout');
+    if (tasks.length && scouts.length === 0 && !queued) {
+      // spawn a new scout in the first colony with tasks
+      const colony = tasks[0].colony;
+      const room = Game.rooms[colony];
+      if (!room) return;
+      const spawn = room.find(FIND_MY_SPAWNS)[0];
+      if (!spawn) return;
+      spawnQueue.addToQueue(
+        'scout',
+        colony,
+        [MOVE],
+        { role: 'scout', assignment: 'hiveGaze', homeRoom: colony },
+        spawn.id,
+        0,
+        spawnManager.ROLE_PRIORITY.scout || 0,
+      );
+      if (Memory.settings && Memory.settings.debugHiveGaze) {
+        statsConsole.log('[HiveGaze] Scout missing, spawning new', 3);
+      }
+    }
+  },
+
+  remoteScoreRoom({ roomName, colony }) {
+    const mem = Memory.rooms[roomName];
+    if (!mem || !mem.sources) return;
+    if (!Game.rooms[roomName]) {
+      if (Memory.settings && Memory.settings.debugHiveGaze) {
+        statsConsole.log(`[HiveGaze] Remote score skipped for ${roomName}, not visible`, 3);
+      }
+      htm.addColonyTask(
+        colony || mem.homeColony,
+        'REMOTE_SCORE_ROOM',
+        { roomName, colony: colony || mem.homeColony },
+        4,
+        50,
+        1,
+        'hiveGaze',
+        { module: 'hiveGaze', createdBy: 'remoteScoreRetry', tickCreated: Game.time },
+      );
+      return;
+    }
+    const colonyId = colony || mem.homeColony;
+    const room = Game.rooms[colonyId];
+    if (!room) return;
+    const spawn = room.find(FIND_MY_SPAWNS)[0];
+    if (!spawn) return;
+    let total = 0;
+    for (const id in mem.sources) {
+      const data = mem.sources[id];
+      const result = PathFinder.search(spawn.pos, { pos: new RoomPosition(data.pos.x, data.pos.y, roomName), range: 1 }, { swampCost: 2, plainCost: 2, ignoreCreeps: true });
+      const len = result.path.length;
+      const score = Math.max(0, 100 - len * 2);
+      mem.sources[id].pathLengthToSpawn = len;
+      mem.sources[id].score = score;
+      total += score;
+    }
+    mem.remoteScore = total;
+    if (Memory.settings && Memory.settings.debugHiveGaze) {
+      statsConsole.log(`[HiveGaze] Scored remote room ${roomName}: ${total}`, 3);
+    }
+  },
+
+  initRemoteMiner({ room, sourceId }) {
+    const mem = Memory.rooms[room];
+    if (!mem || !mem.sources || !mem.sources[sourceId]) return;
+    const colony = mem.homeColony;
+    const base = Game.rooms[colony];
+    if (!base) return;
+    const spawn = base.find(FIND_MY_SPAWNS)[0];
+    if (!spawn) return;
+    const pos = mem.sources[sourceId].pos;
+    const terrain = Game.map.getRoomTerrain(room);
+    const offsets = [-1, 0, 1];
+    let best = null;
+    let bestLen = Infinity;
+    for (const dx of offsets) {
+      for (const dy of offsets) {
+        const x = pos.x + dx;
+        const y = pos.y + dy;
+        if (x < 0 || x > 49 || y < 0 || y > 49) continue;
+        if (terrain.get(x, y) !== TERRAIN_MASK_WALL) {
+          const res = PathFinder.search(
+            spawn.pos,
+            { pos: new RoomPosition(x, y, room), range: 1 },
+            { swampCost: 2, plainCost: 2, ignoreCreeps: true },
+          );
+          if (res.path.length < bestLen) {
+            bestLen = res.path.length;
+            best = { x, y };
+          }
+        }
+      }
+    }
+    if (!best) {
+      if (Memory.settings && Memory.settings.debugHiveGaze) {
+        statsConsole.log(`[HiveGaze] No walkable tile near ${sourceId} in ${room}`, 2);
+      }
+      return;
+    }
+    mem.sources[sourceId].assignedPosition = best;
+    mem.sources[sourceId].reservedBy = 'remoteMiner';
+    spawnQueue.addToQueue(
+      'remoteMiner',
+      colony,
+      [MOVE, WORK, WORK, WORK, WORK, WORK],
+      { role: 'remoteMiner', targetSourceId: sourceId, targetRoom: room, assignedPos: best, homeRoom: colony },
+      spawn.id,
+      0,
+      spawnManager.PRIORITY_REMOTE_MINER,
+    );
+    if (Memory.settings && Memory.settings.debugHiveGaze) {
+      statsConsole.log(`[HiveGaze] Queued remote miner for ${room}`, 3);
+    }
+  },
+
+  reserveRemoteRoom({ room }) {
+    const mem = Memory.rooms[room];
+    if (!mem) return;
+    const colony = mem.homeColony;
+    const base = Game.rooms[colony];
+    if (!base) return;
+    const spawn = base.find(FIND_MY_SPAWNS)[0];
+    if (!spawn) return;
+    spawnQueue.addToQueue(
+      'reservist',
+      colony,
+      [MOVE, WORK],
+      { role: 'reservist', targetRoom: room, homeRoom: colony },
+      spawn.id,
+      0,
+      spawnManager.PRIORITY_RESERVIST,
+    );
+    if (Memory.settings && Memory.settings.debugHiveGaze) {
+      statsConsole.log(`[HiveGaze] Queued reservist for ${room}`, 3);
+    }
+  },
+
+  selectExpansionTarget() {
+    let best = null;
+    let bestScore = 0;
+    for (const r in Memory.rooms) {
+      const mem = Memory.rooms[r];
+      if (typeof mem.remoteScore === 'number' && mem.remoteScore > bestScore) {
+        best = r;
+        bestScore = mem.remoteScore;
+      }
+    }
+    if (best) {
+      Memory.hive.expansionTarget = best;
+      const sources = Memory.rooms[best].sources || {};
+      const bestSrc = _.maxBy(Object.keys(sources), id => sources[id].score);
+      if (bestSrc) {
+        if (!htm.hasTask(htm.LEVELS.COLONY, Memory.rooms[best].homeColony, 'REMOTE_MINER_INIT')) {
+          htm.addColonyTask(Memory.rooms[best].homeColony, 'REMOTE_MINER_INIT', { room: best, sourceId: bestSrc }, 2, 500, 1, 'hiveGaze', { module: 'hiveGaze', createdBy: 'selectExpansionTarget', tickCreated: Game.time });
+          htm.addColonyTask(Memory.rooms[best].homeColony, 'RESERVE_REMOTE_ROOM', { room: best }, 3, 500, 1, 'hiveGaze', { module: 'hiveGaze', createdBy: 'selectExpansionTarget', tickCreated: Game.time });
+        }
+      }
+    }
+  },
+
+  /** Track active remote rooms in Memory.hive.claimedRemotes
+   *  @codex-owner hiveGaze
+   */
+  updateClaimedRemotes() {
+    if (!Memory.hive) Memory.hive = {};
+    if (!Memory.hive.claimedRemotes) Memory.hive.claimedRemotes = [];
+    const active = new Set();
+    // remote miners keep rooms active
+    for (const name in Game.creeps) {
+      const c = Game.creeps[name];
+      if (c.memory.role === 'remoteMiner') {
+        active.add(c.memory.targetRoom);
+      } else if (c.memory.role === 'reservist' && c.room.controller && c.room.controller.reservation && c.room.controller.reservation.username === (Memory.username || '')) {
+        active.add(c.room.name);
+      }
+    }
+    // check existing reservations in memory
+    for (const roomName in Memory.rooms) {
+      const mem = Memory.rooms[roomName];
+      const reserved = _.get(mem, ['controller', 'owner']) === (Memory.username || '') && _.get(mem, ['controller', 'reservationTicks'], 0) >= 1000;
+      const hasMiner = _.some(Game.creeps, c => c.memory.role === 'remoteMiner' && c.memory.targetRoom === roomName);
+      if (hasMiner || reserved) active.add(roomName);
+    }
+    Memory.hive.claimedRemotes = Array.from(active);
+  },
+};
+
+module.exports = hiveGaze;
+
+htm.registerHandler(htm.LEVELS.COLONY, 'REMOTE_SCORE_ROOM', hiveGaze.remoteScoreRoom);
+htm.registerHandler(htm.LEVELS.COLONY, 'REMOTE_MINER_INIT', hiveGaze.initRemoteMiner);
+htm.registerHandler(htm.LEVELS.COLONY, 'RESERVE_REMOTE_ROOM', hiveGaze.reserveRemoteRoom);

--- a/manager.hivemind.js
+++ b/manager.hivemind.js
@@ -1,5 +1,6 @@
 const htm = require('./manager.htm');
 const spawnModule = require('./manager.hivemind.spawn');
+const hiveGaze = require('./manager.hiveGaze');
 const scheduler = require('./scheduler');
 const memoryManager = require('./manager.memory');
 const roomManager = require('./manager.room');
@@ -52,6 +53,16 @@ const hivemind = {
         }
       }
     }
+
+    hiveGaze.updateClaimedRemotes();
+  },
+
+  /** Delegate expansion vision checks to HiveGaze */
+  evaluateExpansionVision() {
+    hiveGaze.evaluateExpansionVision();
+  },
+  manageScouts() {
+    hiveGaze.manageScouts();
   },
 };
 

--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -9,12 +9,19 @@ const energyRequests = require("./manager.energyRequests");
 
 // Default spawn priorities per role
 const ROLE_PRIORITY = {
+  scout: 0,
   allPurpose: 1,
   miner: 2,
   hauler: 3,
   builder: 4,
   upgrader: 5,
+  remoteMiner: 2,
+  reservist: 3,
 };
+
+// Exportable priority shortcuts for remote roles
+const PRIORITY_REMOTE_MINER = ROLE_PRIORITY.remoteMiner;
+const PRIORITY_RESERVIST = ROLE_PRIORITY.reservist;
 
 // Exportable priority constants for external modules
 const PRIORITY_HIGH = ROLE_PRIORITY.miner;
@@ -653,4 +660,7 @@ const spawnManager = {
 
 module.exports = spawnManager;
 module.exports.PRIORITY_HIGH = PRIORITY_HIGH;
+module.exports.PRIORITY_SCOUT = ROLE_PRIORITY.scout;
+module.exports.PRIORITY_REMOTE_MINER = PRIORITY_REMOTE_MINER;
+module.exports.PRIORITY_RESERVIST = PRIORITY_RESERVIST;
 module.exports.ROLE_PRIORITY = ROLE_PRIORITY;

--- a/role.remoteMiner.js
+++ b/role.remoteMiner.js
@@ -1,0 +1,66 @@
+const roleRemoteMiner = {
+  run(creep) {
+    const roomName = creep.memory.targetRoom;
+    if (!Memory.stats) Memory.stats = {};
+    if (!Memory.stats.remoteRooms) Memory.stats.remoteRooms = {};
+    if (!Memory.stats.remoteRooms[roomName]) {
+      Memory.stats.remoteRooms[roomName] = {
+        minerSpawns: 0,
+        minerDeaths: 0,
+        minerFails: 0,
+        reservistSpawns: 0,
+        reservistSuccesses: 0,
+        reservistFails: 0,
+      };
+    }
+    const stats = Memory.stats.remoteRooms[roomName];
+    if (!creep.memory.countedSpawn) {
+      stats.minerSpawns++;
+      creep.memory.countedSpawn = true;
+    }
+    if (!creep.memory.assignedPos) {
+      stats.minerFails++;
+      stats.minerDeaths++;
+      creep.suicide();
+      return;
+    }
+    const pos = new RoomPosition(
+      creep.memory.assignedPos.x,
+      creep.memory.assignedPos.y,
+      creep.memory.targetRoom,
+    );
+    if (!creep.pos.isEqualTo(pos)) {
+      creep.travelTo(pos);
+      if (creep.memory.lastPos && creep.pos.x === creep.memory.lastPos.x && creep.pos.y === creep.memory.lastPos.y && creep.pos.roomName === creep.memory.lastPos.roomName) {
+        creep.memory.stuckTicks = (creep.memory.stuckTicks || 0) + 1;
+      } else {
+        creep.memory.stuckTicks = 0;
+        creep.memory.lastPos = { x: creep.pos.x, y: creep.pos.y, roomName: creep.pos.roomName };
+      }
+      if (creep.memory.stuckTicks >= 5) {
+        if (Memory.settings && Memory.settings.debugHiveGaze) {
+          const statsConsole = require('console.console');
+          statsConsole.log(`[HiveGaze] RemoteMiner ${creep.name} stuck, terminating`, 2);
+        }
+        stats.minerFails++;
+        stats.minerDeaths++;
+        creep.suicide();
+      }
+      return;
+    }
+    const source = Game.getObjectById(creep.memory.targetSourceId);
+    if (!source) {
+      if (Memory.settings && Memory.settings.debugHiveGaze) {
+        const statsConsole = require('console.console');
+        statsConsole.log(`[HiveGaze] RemoteMiner ${creep.name} missing source`, 2);
+      }
+      stats.minerFails++;
+      stats.minerDeaths++;
+      creep.suicide();
+      return;
+    }
+    creep.harvest(source);
+  },
+};
+
+module.exports = roleRemoteMiner;

--- a/role.reservist.js
+++ b/role.reservist.js
@@ -1,0 +1,81 @@
+const { getRandomTyranidQuote } = require('./utils.quotes');
+const _ = require('lodash');
+
+const roleReservist = {
+  run(creep) {
+    const roomName = creep.memory.targetRoom;
+    if (!Memory.stats) Memory.stats = {};
+    if (!Memory.stats.remoteRooms) Memory.stats.remoteRooms = {};
+    if (!Memory.stats.remoteRooms[roomName]) {
+      Memory.stats.remoteRooms[roomName] = {
+        minerSpawns: 0,
+        minerDeaths: 0,
+        minerFails: 0,
+        reservistSpawns: 0,
+        reservistSuccesses: 0,
+        reservistFails: 0,
+      };
+    }
+    const stats = Memory.stats.remoteRooms[roomName];
+    if (!creep.memory.countedSpawn) {
+      stats.reservistSpawns++;
+      creep.memory.countedSpawn = true;
+    }
+    if (creep.room.name !== roomName) {
+      creep.travelTo(new RoomPosition(25, 25, roomName));
+      return;
+    }
+    const controller = creep.room.controller;
+    if (!controller) {
+      if (Memory.settings && Memory.settings.debugHiveGaze) {
+        const statsConsole = require('console.console');
+        statsConsole.log(`[HiveGaze] Reservist ${creep.name} no controller in ${creep.room.name}`, 2);
+      }
+      stats.reservistFails++;
+      creep.suicide();
+      return;
+    }
+    if (
+      controller.reservation &&
+      controller.reservation.username &&
+      !controller.my &&
+      controller.reservation.username !== (Memory.username || '')
+    ) {
+      const attempts = _.get(Memory, ['rooms', roomName, 'reserveAttempts'], 0);
+      if (attempts < 3) {
+        _.set(Memory, ['rooms', roomName, 'reserveAttempts'], attempts + 1);
+        const delay = 1000 + Math.floor(Math.random() * 500);
+        const colony = creep.memory.homeRoom || _.get(Memory, ['rooms', roomName, 'homeColony']);
+        const htm = require('./manager.htm');
+        htm.addColonyTask(
+          colony,
+          'RESERVE_REMOTE_ROOM',
+          { room: roomName },
+          4,
+          delay,
+          1,
+          'autoRetry',
+          { module: 'role.reservist', createdBy: 'reserveRetry', tickCreated: Game.time },
+        );
+      }
+      if (Memory.settings && Memory.settings.debugHiveGaze) {
+        const statsConsole = require('console.console');
+        statsConsole.log(`[HiveGaze] Reservist failed to claim ${roomName}`, 3);
+      }
+      stats.reservistFails++;
+      creep.suicide();
+      return;
+    }
+    const res = creep.reserveController(controller);
+    if (res === OK && controller.sign) {
+      controller.sign(creep, getRandomTyranidQuote());
+      _.set(Memory, ['rooms', roomName, 'reserveAttempts'], 0);
+      stats.reservistSuccesses++;
+    } else if (res !== OK) {
+      stats.reservistFails++;
+    }
+    creep.suicide();
+  },
+};
+
+module.exports = roleReservist;

--- a/role.scout.js
+++ b/role.scout.js
@@ -1,0 +1,174 @@
+const htm = require('./manager.htm');
+const hiveGaze = require('./manager.hiveGaze');
+const _ = require('lodash');
+const statsConsole = require('console.console');
+
+const roleScout = {
+  run(creep) {
+    if (!creep.memory.homeRoom) creep.memory.homeRoom = creep.room.name;
+
+    // Clear idle flag when expired
+    if (creep.memory.idle && Game.time >= creep.memory.idleUntil) {
+      delete creep.memory.idle;
+      delete creep.memory.idleUntil;
+    }
+
+    if (creep.memory.idle) {
+      const basePos = _.get(
+        Memory,
+        ['hive', 'clusters', creep.memory.homeRoom, 'colonies', creep.memory.homeRoom, 'meta', 'basePos'],
+      );
+      if (basePos) creep.travelTo(new RoomPosition(basePos.x, basePos.y, creep.memory.homeRoom));
+      return;
+    }
+
+    if (creep.ticksToLive && creep.ticksToLive < 50 && creep.memory.targetRoom) {
+      const targetMem = Memory.rooms[creep.memory.targetRoom] || (Memory.rooms[creep.memory.targetRoom] = {});
+      targetMem.scoutFailLog = (targetMem.scoutFailLog || []).filter(t => Game.time - t <= 1000);
+      targetMem.scoutFailLog.push(Game.time);
+      if (targetMem.scoutFailLog.length >= 3) {
+        targetMem.scoutCooldownUntil = Game.time + 1000;
+        targetMem.scoutFailLog = [];
+      }
+      if (!targetMem.scoutCooldownUntil || targetMem.scoutCooldownUntil <= Game.time) {
+        htm.addColonyTask(
+          creep.memory.homeRoom,
+          'SCOUT_ROOM',
+          { roomName: creep.memory.targetRoom },
+          5,
+          500,
+          1,
+          'hiveGaze',
+          { module: 'role.scout', createdBy: 'ttlRequeue', tickCreated: Game.time },
+        );
+        if (Memory.settings && Memory.settings.debugHiveGaze) {
+          statsConsole.log(
+            `[HiveGaze] Scout retiring mid-task, re-queued ${creep.memory.targetRoom}`,
+            3,
+          );
+        }
+      } else if (Memory.settings && Memory.settings.debugHiveGaze) {
+        statsConsole.log(
+          `[HiveGaze] Scout ${creep.name} giving up on ${creep.memory.targetRoom} due to cooldown`,
+          3,
+        );
+      }
+      creep.memory.retiring = true;
+      delete creep.memory.targetRoom;
+      delete creep.memory.taskId;
+      return;
+    }
+
+    if (!creep.memory.targetRoom) {
+      const container = _.get(Memory, ['htm', 'colonies', creep.memory.homeRoom]);
+      if (container && container.tasks) {
+        const tasks = container.tasks.filter(t => t.name === 'SCOUT_ROOM');
+        const task = _.minBy(tasks, t => {
+          return Game.map.getRoomLinearDistance
+            ? Game.map.getRoomLinearDistance(creep.room.name, t.data.roomName)
+            : 0;
+        });
+        if (task) {
+          creep.memory.targetRoom = task.data.roomName;
+          creep.memory.taskId = task.id;
+          htm.claimTask(htm.LEVELS.COLONY, creep.memory.homeRoom, 'SCOUT_ROOM', 'hiveGaze');
+          if (Memory.settings && Memory.settings.debugHiveGaze) {
+            statsConsole.log(`[HiveGaze] Scout ${creep.name} scouting ${task.data.roomName}`, 3);
+          }
+        }
+      }
+    }
+
+    if (creep.memory.targetRoom) {
+      if (creep.room.name !== creep.memory.targetRoom) {
+        creep.travelTo(new RoomPosition(25, 25, creep.memory.targetRoom), { range: 20 });
+        return;
+      }
+      const roomName = creep.room.name;
+      if (!Memory.rooms[roomName]) Memory.rooms[roomName] = {};
+      const sources = creep.room.find(FIND_SOURCES);
+      Memory.rooms[roomName].sources = {};
+      for (const s of sources) {
+        Memory.rooms[roomName].sources[s.id] = { pos: { x: s.pos.x, y: s.pos.y } };
+      }
+      Object.assign(Memory.rooms[roomName], {
+        lastScouted: Game.time,
+        sourceCount: sources.length,
+        homeColony: creep.memory.homeRoom,
+        controller: {
+          exists: !!creep.room.controller,
+          owner: creep.room.controller && creep.room.controller.owner
+            ? creep.room.controller.owner.username
+            : null,
+          reservationTicks: creep.room.controller && creep.room.controller.reservation
+            ? creep.room.controller.reservation.ticksToEnd
+            : 0,
+        },
+        hostilePresent: creep.room.find(FIND_HOSTILE_CREEPS).length > 0,
+        terrainScore: hiveGaze.scoreTerrain(roomName),
+        exits: Object.values(Game.map.describeExits(roomName) || {}),
+        remoteScore: null,
+      });
+      if (Memory.settings && Memory.settings.debugHiveGaze) {
+        statsConsole.log(
+          `[HiveGaze] Scouted ${roomName}, sources: ${Memory.rooms[roomName].sourceCount}`,
+          3,
+        );
+      }
+      Memory.rooms[roomName].scoutFailLog = [];
+      htm.addColonyTask(
+        creep.memory.homeRoom,
+        'REMOTE_SCORE_ROOM',
+        { roomName, colony: creep.memory.homeRoom },
+        4,
+        500,
+        1,
+        'hiveGaze',
+        { module: 'role.scout', createdBy: 'scoutComplete', tickCreated: Game.time },
+      );
+      const container = _.get(Memory, ['htm', 'colonies', creep.memory.homeRoom]);
+      if (container && container.tasks) {
+        const idx = container.tasks.findIndex(t => t.id === creep.memory.taskId);
+        if (idx !== -1) container.tasks.splice(idx, 1);
+      }
+      delete creep.memory.targetRoom;
+      delete creep.memory.taskId;
+    } else {
+      const container = _.get(Memory, ['htm', 'colonies', creep.memory.homeRoom]);
+      const tasks = container && container.tasks ? container.tasks.filter(t => t.name === 'SCOUT_ROOM') : [];
+      if (!tasks.length) {
+        creep.memory.idle = true;
+        creep.memory.idleUntil = Game.time + 5;
+        const basePos = _.get(
+          Memory,
+          ['hive', 'clusters', creep.memory.homeRoom, 'colonies', creep.memory.homeRoom, 'meta', 'basePos'],
+        );
+        if (basePos) {
+          creep.travelTo(new RoomPosition(basePos.x, basePos.y, creep.memory.homeRoom));
+          if (Memory.settings && Memory.settings.debugHiveGaze) {
+            statsConsole.log(`[HiveGaze] ${creep.name} returning to base`, 3);
+          }
+        }
+        else if (Memory.settings && Memory.settings.debugHiveGaze) {
+          statsConsole.log(`[HiveGaze] Warning: no basePos for ${creep.memory.homeRoom}`, 3);
+        }
+      } else if (!creep.memory.idle) {
+        const next = _.minBy(tasks, t => {
+          return Game.map.getRoomLinearDistance
+            ? Game.map.getRoomLinearDistance(creep.room.name, t.data.roomName)
+            : 0;
+        });
+        if (next) {
+          creep.memory.targetRoom = next.data.roomName;
+          creep.memory.taskId = next.id;
+          htm.claimTask(htm.LEVELS.COLONY, creep.memory.homeRoom, 'SCOUT_ROOM', 'hiveGaze');
+          if (Memory.settings && Memory.settings.debugHiveGaze) {
+            statsConsole.log(`[HiveGaze] Scout ${creep.name} scouting ${next.data.roomName}`, 3);
+          }
+        }
+      }
+    }
+  },
+};
+
+module.exports = roleScout;

--- a/taskDefinitions.js
+++ b/taskDefinitions.js
@@ -72,4 +72,29 @@ taskRegistry.register('defendRoom', {
   trigger: { type: 'event', eventName: 'hostilesDetected' },
 });
 
+taskRegistry.register('SCOUT_ROOM', {
+  owner: 'hiveGaze',
+  priority: 5,
+  ttl: 500,
+  trigger: { type: 'condition', conditionFn: 'hiveGaze.evaluateExpansionVision' },
+});
+
+taskRegistry.register('REMOTE_SCORE_ROOM', {
+  owner: 'hiveGaze',
+  priority: 4,
+  ttl: 500,
+});
+
+taskRegistry.register('REMOTE_MINER_INIT', {
+  owner: 'hiveGaze',
+  priority: 2,
+  ttl: 500,
+});
+
+taskRegistry.register('RESERVE_REMOTE_ROOM', {
+  owner: 'hiveGaze',
+  priority: 3,
+  ttl: 500,
+});
+
 module.exports = taskRegistry;

--- a/test/hiveGaze.test.js
+++ b/test/hiveGaze.test.js
@@ -1,0 +1,63 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const hiveGaze = require('../manager.hiveGaze');
+const htm = require('../manager.htm');
+
+global.FIND_MY_SPAWNS = 1;
+
+describe('hiveGaze.evaluateExpansionVision', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    Memory.rooms = { W1N1: {} };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find: (type) => {
+        if (type === FIND_MY_SPAWNS) return [{ id: 's1', pos: { x:25, y:25 } }];
+        return [];
+      },
+    };
+    Game.map.describeExits = () => ({ 1: 'W1N2' });
+  });
+
+  it('queues scout tasks for unexplored exits', function() {
+    hiveGaze.evaluateExpansionVision();
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    expect(tasks.length).to.equal(1);
+    expect(tasks[0].name).to.equal('SCOUT_ROOM');
+    expect(Memory.hive.expansionVisionLastCheck).to.equal(Game.time);
+  });
+
+  it('skips rooms on scout cooldown', function() {
+    Memory.rooms['W1N2'] = { scoutCooldownUntil: Game.time + 50 };
+    hiveGaze.evaluateExpansionVision();
+    const container = Memory.htm.colonies['W1N1'];
+    expect(container).to.be.undefined;
+  });
+});
+
+describe('hiveGaze.manageScouts', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find: type => (type === FIND_MY_SPAWNS ? [{ id: 's1', pos: { x:25,y:25 }, room: { name: 'W1N1' } }] : [])
+    };
+    Memory.htm.colonies = { W1N1: { tasks: [{ name: 'SCOUT_ROOM', id: 't1', data: { roomName: 'W1N2' }, priority: 5, ttl: 500, age:0, amount:1 }] } };
+    const spawnQueue = require('../manager.spawnQueue');
+    spawnQueue.queue = [];
+  });
+
+  it('queues a scout when none exist', function() {
+    hiveGaze.manageScouts();
+    const spawnQueue = require('../manager.spawnQueue');
+    expect(spawnQueue.queue.length).to.equal(1);
+    expect(spawnQueue.queue[0].category).to.equal('scout');
+  });
+});
+

--- a/test/remotePipeline.test.js
+++ b/test/remotePipeline.test.js
@@ -1,0 +1,70 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const hiveGaze = require('../manager.hiveGaze');
+const htm = require('../manager.htm');
+const spawnQueue = require('../manager.spawnQueue');
+const { getRandomTyranidQuote, tyranidQuotes } = require('../utils.quotes');
+
+global.FIND_MY_SPAWNS = 1;
+global.TERRAIN_MASK_WALL = 1;
+
+describe('remote pipeline', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    spawnQueue.queue = [];
+    this.oldPF = global.PathFinder;
+    global.PathFinder = { search: () => ({ path: [{x:5,y:5}], incomplete:false }) };
+    Memory.rooms = {
+      W1N2: { sources: { s1:{ pos:{x:10,y:10} } }, homeColony:'W1N1' }
+    };
+    Game.rooms['W1N2'] = { name:'W1N2', find: () => [], controller: {} };
+    Game.rooms['W1N1'] = {
+      name:'W1N1',
+      controller:{ my:true },
+      find:type=> type===FIND_MY_SPAWNS ? [{id:'s1', pos:{x:25,y:25}}] : []
+    };
+  });
+
+  afterEach(function() {
+    global.PathFinder = this.oldPF;
+  });
+
+  it('scores remote room and stores result', function() {
+    hiveGaze.remoteScoreRoom({ roomName:'W1N2', colony:'W1N1' });
+    expect(Memory.rooms.W1N2.remoteScore).to.be.above(0);
+    expect(Memory.rooms.W1N2.sources.s1.score).to.be.a('number');
+  });
+
+  it('queues remote miner on init', function() {
+    hiveGaze.initRemoteMiner({ room:'W1N2', sourceId:'s1' });
+    expect(Memory.rooms.W1N2.sources.s1.assignedPosition).to.be.an('object');
+    expect(spawnQueue.queue.length).to.equal(1);
+  });
+
+  it('requeues scoring when room not visible', function() {
+    Memory.htm.colonies = { W1N1: { tasks: [] } };
+    delete Game.rooms['W1N2'];
+    hiveGaze.remoteScoreRoom({ roomName:'W1N2', colony:'W1N1' });
+    const tasks = Memory.htm.colonies.W1N1.tasks;
+    expect(tasks.length).to.equal(1);
+    expect(tasks[0].name).to.equal('REMOTE_SCORE_ROOM');
+    expect(tasks[0].ttl).to.equal(50);
+    expect(Memory.rooms.W1N2.remoteScore).to.be.undefined;
+  });
+
+  it('skips miner init when no walkable tile', function() {
+    const oldTerrain = Game.map.getRoomTerrain;
+    Game.map.getRoomTerrain = () => ({ get: () => TERRAIN_MASK_WALL });
+    hiveGaze.initRemoteMiner({ room:'W1N2', sourceId:'s1' });
+    expect(spawnQueue.queue.length).to.equal(0);
+    expect(Memory.rooms.W1N2.sources.s1.assignedPosition).to.be.undefined;
+    Game.map.getRoomTerrain = oldTerrain;
+  });
+
+  it('returns a tyranid quote', function() {
+    const quote = getRandomTyranidQuote();
+    expect(tyranidQuotes).to.include(quote);
+  });
+});

--- a/test/roleReservist.test.js
+++ b/test/roleReservist.test.js
@@ -1,0 +1,32 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const roleReservist = require('../role.reservist');
+const htm = require('../manager.htm');
+
+global.OK = 0;
+
+describe('role.reservist', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory({ stats: { logs: [] } });
+    htm.init();
+    Memory.htm.colonies['W1N1'] = { tasks: [] };
+  });
+
+  it('queues retry when controller reserved by others', function() {
+    Game.rooms['W1N5'] = { name:'W1N5', controller:{ reservation:{ username:'enemy' }, my:false } };
+    const creep = { name:'r1', memory:{ role:'reservist', targetRoom:'W1N5', homeRoom:'W1N1' }, room: Game.rooms['W1N5'], travelTo:()=>{}, suicide:()=>{ creep.died = true; } };
+    roleReservist.run(creep);
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    expect(tasks.length).to.equal(1);
+    expect(tasks[0].manager).to.equal('autoRetry');
+    expect(creep.died).to.be.true;
+  });
+
+  it('suicides when no controller present', function() {
+    Game.rooms['W1N5'] = { name:'W1N5', controller:null };
+    const creep = { name:'r2', memory:{ role:'reservist', targetRoom:'W1N5' }, room: Game.rooms['W1N5'], travelTo:()=>{}, suicide:()=>{ creep.died = true; } };
+    roleReservist.run(creep);
+    expect(creep.died).to.be.true;
+  });
+});

--- a/test/roleScout.test.js
+++ b/test/roleScout.test.js
@@ -1,0 +1,93 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const roleScout = require('../role.scout');
+const htm = require('../manager.htm');
+
+global.FIND_SOURCES = 1;
+global.FIND_HOSTILE_CREEPS = 2;
+
+describe('role.scout', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    Memory.rooms = { W1N2: {} };
+    Memory.htm.colonies['W1N1'] = { tasks: [{ name: 'SCOUT_ROOM', id: 't1', data: { roomName: 'W1N2' }, priority: 5, ttl: 500, age:0, amount:1 }] };
+    Game.rooms['W1N1'] = { name: 'W1N1', controller: { my: true }, find: () => [] };
+    Game.rooms['W1N2'] = { name: 'W1N2', find: type => [], controller: null };
+    Game.map.describeExits = () => ({ 1:'W1N3' });
+    const terrain = { get: () => 0 };
+    Game.map.getRoomTerrain = () => terrain;
+    Game.map.getRoomLinearDistance = () => 1;
+    Game.creeps.sc1 = { name: 'sc1', memory: { role: 'scout', homeRoom: 'W1N1' }, room: Game.rooms['W1N2'], travelTo: () => {} };
+  });
+
+  it('updates memory when scouting room', function() {
+    roleScout.run(Game.creeps.sc1);
+    expect(Memory.rooms['W1N2'].lastScouted).to.equal(Game.time);
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    expect(tasks[0].name).to.equal('REMOTE_SCORE_ROOM');
+  });
+
+  it('requeues task when ttl low', function() {
+    Game.creeps.sc1.ticksToLive = 40;
+    Game.creeps.sc1.memory.targetRoom = 'W1N2';
+    Memory.htm.colonies['W1N1'].tasks = [];
+    roleScout.run(Game.creeps.sc1);
+    const tasks = Memory.htm.colonies['W1N1'].tasks;
+    expect(tasks.length).to.equal(1);
+    expect(tasks[0].name).to.equal('SCOUT_ROOM');
+    expect(Game.creeps.sc1.memory.retiring).to.be.true;
+  });
+
+  it('applies cooldown after repeated failures', function() {
+    Memory.htm.colonies['W1N1'].tasks = [];
+    Game.creeps.sc1.ticksToLive = 40;
+    Game.creeps.sc1.memory.targetRoom = 'W1N2';
+    for (let i = 0; i < 3; i++) {
+      Game.time = i * 300;
+      roleScout.run(Game.creeps.sc1);
+      Game.creeps.sc1.memory.targetRoom = 'W1N2';
+    }
+    expect(Memory.rooms['W1N2'].scoutCooldownUntil).to.be.a('number');
+    expect(Memory.rooms['W1N2'].scoutCooldownUntil).to.be.above(Game.time);
+    expect((Memory.htm.colonies['W1N1'].tasks || []).length).to.equal(1);
+  });
+
+  it('suppresses task claims when idle', function() {
+    Game.creeps.sc1.room = Game.rooms['W1N1'];
+    Game.creeps.sc1.travelTo = () => {};
+    Memory.htm.colonies['W1N1'].tasks = [];
+    Memory.hive = { clusters: { W1N1: { colonies: { W1N1: { meta: { basePos: { x:5, y:5 } } } } } } };
+    roleScout.run(Game.creeps.sc1);
+    expect(Game.creeps.sc1.memory.idle).to.be.true;
+    Game.time += 3;
+    Memory.htm.colonies['W1N1'].tasks.push({ name:'SCOUT_ROOM', id:'t2', data:{ roomName:'W1N2' }, priority:5, ttl:500, age:0, amount:1 });
+    roleScout.run(Game.creeps.sc1);
+    expect(Game.creeps.sc1.memory.targetRoom).to.be.undefined;
+    Game.time = Game.creeps.sc1.memory.idleUntil;
+    roleScout.run(Game.creeps.sc1);
+    expect(Game.creeps.sc1.memory.targetRoom).to.equal('W1N2');
+  });
+
+  it('moves to base when idle', function() {
+    let moved = false;
+    Game.creeps.sc1.room = Game.rooms['W1N1'];
+    Game.creeps.sc1.travelTo = () => { moved = true; };
+    Memory.htm.colonies['W1N1'].tasks = [];
+    Memory.hive = { clusters: { W1N1: { colonies: { W1N1: { meta: { basePos: { x:5, y:5 } } } } } } };
+    roleScout.run(Game.creeps.sc1);
+    expect(moved).to.be.true;
+  });
+
+  it('logs when debug enabled', function() {
+    globals.resetMemory({ stats: { logs: [] }, settings: { debugHiveGaze: true } });
+    htm.init();
+    Memory.rooms = { W1N2: {} };
+    Game.rooms['W1N2'] = { name: 'W1N2', find: type => [], controller: null };
+    Memory.htm.colonies['W1N1'] = { tasks: [{ name: 'SCOUT_ROOM', id: 't1', data: { roomName: 'W1N2' }, priority:5, ttl:500, age:0, amount:1 }] };
+    Game.creeps.sc1.room = Game.rooms['W1N2'];
+    roleScout.run(Game.creeps.sc1);
+    expect(Memory.stats.logs.length).to.be.above(0);
+  });
+});

--- a/utils.quotes.js
+++ b/utils.quotes.js
@@ -1,0 +1,23 @@
+const tyranidQuotes = [
+  "We are the swarm.",
+  "There is only the Hive.",
+  "Biomass will be consumed.",
+  "The flesh is weak. Feed it.",
+  "Worlds are but nutrients.",
+  "Assimilation is survival.",
+  "Your fate is digestion.",
+  "The Hive Mind watches.",
+  "Evolve or perish.",
+  "We devour stars.",
+  "Silence the prey.",
+  "Your end is inevitable.",
+  "We are many. You are one.",
+  "Flesh and bone, fuel alone.",
+  "The swarm hungers."
+];
+
+function getRandomTyranidQuote() {
+  return tyranidQuotes[Math.floor(Math.random() * tyranidQuotes.length)];
+}
+
+module.exports = { tyranidQuotes, getRandomTyranidQuote };


### PR DESCRIPTION
## Summary
- track active remote rooms via `Memory.hive.claimedRemotes`
- requeue reservist tasks when controllers are taken, limited by `reserveAttempts`
- record spawn/failure stats for remote miners and reservists
- gate new HiveGaze logs behind `debugHiveGaze`
- document new memory paths and task origin
- update unit tests for reservist retry logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a95981e748327969d7ba929bcc4fa