### PR TITLE
Add dynamic build progress tracking

### DIFF
--- a/docs/Codex.md
+++ b/docs/Codex.md
@@ -1,0 +1,5 @@
+# 📚 Codex Metadata
+
+This file lists modules annotated with `@codex-owner` comments so the documentation generator can link source files to maintainers.
+
+- `layoutPlanner.js` – @codex-owner layoutPlanner

--- a/docs/HUD.md
+++ b/docs/HUD.md
@@ -1,0 +1,10 @@
+# HUD Layout Progress
+
+If `Memory.settings.debugLayoutProgress` is `true`, the layout planner and building manager
+log cluster progress every 1000 ticks. Example console line:
+
+```
+[cluster] W1N1:extCluster1 3/5
+```
+
+This indicates three of the five planned structures in `extCluster1` have been built.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -215,6 +215,8 @@ Memory.settings = {
   showTaskList: false,
   energyLogs: false,
   debugHiveGaze: false,
+  debugBuilding: false,      // log build results and draw visual overlays
+  debugLayoutProgress: false // log layout progress every 1000 ticks
 };
 ```
 
@@ -395,6 +397,19 @@ Memory.rooms['W1N1'].layout = {
   },
   reserved: {
     26: { 25: true }
+  },
+  roadMatrix: {
+    26: { 26: { planned: true, rcl: 1, plannedBy: 'layoutPlanner' } }
+  },
+  rebuildLayout: false
+  status: {
+    clusters: {
+      extCluster1: { built: 3, total: 5, complete: false }
+    }
+    structures: {
+      extension: { built: 8, total: 10 },
+      tower: { built: 1, total: 1 }
+    }
   }
 };
 ```
@@ -402,5 +417,18 @@ Memory.rooms['W1N1'].layout = {
 Tiles listed under `reserved` are blocked from other planners. Future
 versions may include `blockedUntil` timestamps for temporary holds.
 
+`roadMatrix` mirrors the structure matrix but tracks planned road tiles.
+
+Set `rebuildLayout` to `true` if you want the planner to wipe and
+recalculate the layout on the next tick. It resets automatically after
+running.
+
+`status` tracks progress for each planned cluster. `built` counts completed
+structures, `total` is the overall size and `complete` marks when the cluster
+is done. The `structures` section provides overall build totals per structure
+type so HUD overlays and planners can show remaining work.
+
 The helper `constructionBlocker.isTileBlocked(roomName, x, y)` returns `true`
 when a tile is reserved in the layout, preventing conflicting plans.
+Tiles flagged with `invalid: true` are skipped permanently. The building manager
+marks a tile invalid when a layout task attempts to build on unwalkable terrain.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -63,6 +63,7 @@ The main loop registers several core jobs which drive the colony:
 | `clearMemory`        | 100 ticks      | `main`             | Removes dead creep memory. |
 | `updateHUD`          | 5 ticks        | `main`             | Draws HUD visuals. |
 | `layoutPlanningInit` | event `roomOwnershipEstablished` (once) | `layoutPlanner` | Initialize base layout when a room is claimed. |
+| `dynamicLayout` | 100 ticks | `layoutPlanner` | Populate dynamic layout and queue cluster tasks. |
 | `buildInfrastructure`| every tick     | `buildingManager`  | Places construction sites when needed. |
 | `hivemind`           | 1 tick         | `hivemind`         | Evaluates strategy and queues HTM tasks. |
 | `energyDemand`       | 1000 ticks     | `demand`           | Updates delivery stats. |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -63,7 +63,8 @@ taskRegistry.register('upgradeController', {
 | `acquireMiningData` | `roomManager` | 2 | Rescan room to rebuild mining positions. |
 | `buildSite` | `buildingManager` | 1 | Assign builders to a construction site. |
 | `repairEmergency` | `buildingManager` | 1 | Repair structures close to decay. |
-| `BUILD_LAYOUT_PART` | `buildingManager` | 1 | Construct next piece of the base layout (placeholder for HTM integration). | @codex-owner buildingManager
+| `BUILD_LAYOUT_PART` | `buildingManager` | 1 | Construct next piece of the base layout. | @codex-owner buildingManager
+| `BUILD_CLUSTER` | `layoutPlanner` | 4 | Schedule a group of structures to be built as a cluster. Includes `progress` and `complete` fields. | @codex-owner layoutPlanner
 | `REMOTE_SCORE_ROOM` | `hiveGaze` | 4 | Evaluate remote sources and assign scores. |
 | `REMOTE_MINER_INIT` | `hiveGaze` | 2 | Reserve a remote mining spot and spawn a miner. |
 | `RESERVE_REMOTE_ROOM` | `hiveGaze` | 3 | Spawn a reservist to secure the controller. Tasks may be requeued automatically with origin `autoRetry`. |
@@ -88,24 +89,59 @@ Past executions can be inspected under `Memory.stats.taskLogs` when a module cho
 
 Tasks may reference a parent task and maintain a list of subtasks. This allows
 complex objectives to be broken into smaller steps while maintaining a tree
-structure.
+structure. The layout planner queues a `BUILD_CLUSTER` task and then schedules
+`BUILD_LAYOUT_PART` subtasks using the parent's cluster identifier.
 
 ```javascript
 htm.addColonyTask(
   'W1N1',
-  'BUILD_LAYOUT_PART',
-  { x: 25, y: 25, structureType: STRUCTURE_EXTENSION, rcl: 2 },
+  'BUILD_CLUSTER',
+  { roomName: 'W1N1', clusterId: 'extCluster1', rcl: 2, structureType: STRUCTURE_EXTENSION },
   3,
-  50,
+  1500,
   1,
-  'buildingManager',
+  'layoutPlanner',
   {},
-  { parentTaskId: '123', subtaskIds: ['123-1', '123-2'] },
+  { parentTaskId: 'extCluster1' },
+);
+
+htm.addColonyTask(
+  'W1N1',
+  'BUILD_LAYOUT_PART',
+  { roomName: 'W1N1', structureType: STRUCTURE_EXTENSION, x: 21, y: 12 },
+  5,
+  1000,
+  1,
+  'layoutPlanner',
+  { parentTaskId: 'extCluster1' },
 );
 ```
 
 The HTM does not currently enforce parent/child relationships but the fields are
 available for future visualisation and debugging tools.
+
+`BUILD_CLUSTER` tasks are removed automatically once all of their
+`BUILD_LAYOUT_PART` subtasks are completed. Each cluster task contains a
+`progress` field like `"3/5"` and a boolean `complete` once finished.
+
+`BUILD_LAYOUT_PART` tasks are executed by `buildingManager`. The manager checks
+the room's controller level and current structure counts against
+`CONTROLLER_STRUCTURES` before placing a construction site. If a structure is
+already present at the target coordinates, the task is removed and the
+corresponding entry in `Memory.rooms[room].layout.status.structures` is
+incremented. Tasks stay queued until a site is placed or the structure exists.
+
+When `Memory.settings.debugBuilding` is `true`, every task execution logs the
+result to the console and draws a small overlay via `RoomVisual`:
+
+```
+[BUILD] Placed EXTENSION at (17, 24) in W1N1
+[BUILD] Skipped TOWER at (20, 21): RCL limit reached
+[BUILD] Cannot place SPAWN at (10, 10) in W1N1 — unwalkable terrain
+```
+
+A ✅ is drawn when a construction site is created, while ❌ marks skipped tasks
+or invalid tiles. This helps diagnose layout problems and verify build progress.
 
 
 ### Task Registry

--- a/layoutPlanner.js
+++ b/layoutPlanner.js
@@ -1,4 +1,7 @@
 const statsConsole = require('console.console');
+const distanceTransform = require('./algorithm.distanceTransform');
+const htm = require('./manager.htm');
+const constructionBlocker = require('./constructionBlocker');
 
 /**
  * Modular layout planner storing structure matrix per room.
@@ -29,6 +32,16 @@ function reserve(mem, x, y, data) {
 
 const layoutPlanner = {
   /**
+   * Check if a tile is reserved by the planner.
+   * @param {string} roomName
+   * @param {number} x
+   * @param {number} y
+   * @returns {boolean}
+   */
+  isTileBlocked(roomName, x, y) {
+    return constructionBlocker.isTileBlocked(roomName, x, y);
+  },
+  /**
    * Plan layout for given room name using preset matrix.
    * @param {string} roomName
    */
@@ -50,6 +63,243 @@ const layoutPlanner = {
     }
     mem.layout.planVersion = 1;
     statsConsole.run([["layoutPlanner", Game.cpu.getUsed()]]);
+    this.populateDynamicLayout(roomName);
+  },
+
+  /**
+   * Generate dynamic layout positions based on terrain and spawn anchor.
+   * @param {string} roomName
+   * @codex-owner layoutPlanner
+   */
+  populateDynamicLayout(roomName) {
+    const room = Game.rooms[roomName];
+    if (!room || !room.controller || !room.controller.my) return;
+    if (!room.memory.layout || !room.memory.layout.matrix) return;
+    const spawn = room.find(FIND_MY_SPAWNS)[0];
+    if (!spawn) return;
+
+    const mem = room.memory.layout;
+    mem.roadMatrix = mem.roadMatrix || {};
+    mem.status = mem.status || { clusters: {}, structures: {} };
+    if (mem.rebuildLayout) {
+      mem.matrix = {};
+      mem.reserved = {};
+      mem.roadMatrix = {};
+      delete mem.rebuildLayout;
+    }
+
+    if (!room.memory.distanceTransform) {
+      distanceTransform.distanceTransform(room);
+    }
+    const dt = room.memory.distanceTransform;
+
+    function dtVal(x, y) {
+      return dt[y * 50 + x] || 0;
+    }
+
+    function setCell(x, y, type, rcl) {
+      if (x < 1 || x > 48 || y < 1 || y > 48) return false;
+      if (layoutPlanner.isTileBlocked(roomName, x, y)) return false;
+      if (room.lookForAt(LOOK_STRUCTURES, x, y).length > 0) return false;
+      if (!mem.matrix[x]) mem.matrix[x] = {};
+      if (mem.matrix[x][y]) return false;
+      mem.matrix[x][y] = {
+        structureType: type,
+        rcl,
+        planned: true,
+        plannedBy: 'layoutPlanner',
+        blockedUntil: Game.time + 10000,
+      };
+      if (!mem.reserved[x]) mem.reserved[x] = {};
+      mem.reserved[x][y] = true;
+      return true;
+    }
+
+    // Choose open tile near spawn using distance transform
+    let best = spawn.pos;
+    let bestVal = -1;
+    for (let dx = -3; dx <= 3; dx++) {
+      for (let dy = -3; dy <= 3; dy++) {
+        const x = spawn.pos.x + dx;
+        const y = spawn.pos.y + dy;
+        if (x < 1 || x > 48 || y < 1 || y > 48) continue;
+        const val = dtVal(x, y);
+        if (val > bestVal) {
+          bestVal = val;
+          best = new RoomPosition(x, y, roomName);
+        }
+      }
+    }
+
+    // Extension cluster pattern around chosen position
+    const clusterId = 'extCluster1';
+    const clusterPattern = [
+      { dx: 0, dy: -1 },
+      { dx: -1, dy: 0 },
+      { dx: 0, dy: 0 },
+      { dx: 1, dy: 0 },
+      { dx: 0, dy: 1 },
+    ];
+    const clusterPos = [];
+    for (const p of clusterPattern) {
+      const x = best.x + p.dx;
+      const y = best.y + p.dy;
+      if (setCell(x, y, STRUCTURE_EXTENSION, 2)) clusterPos.push({ x, y });
+    }
+
+    if (clusterPos.length > 0 && room.controller.level >= 2) {
+      const queuePos = clusterPos.filter((pos) =>
+        !room
+          .lookForAt(LOOK_STRUCTURES, pos.x, pos.y)
+          .some((s) => s.structureType === STRUCTURE_EXTENSION),
+      );
+      const total = clusterPos.length;
+      mem.status.clusters[clusterId] = mem.status.clusters[clusterId] || {
+        built: total - queuePos.length,
+        total,
+        complete: false,
+      };
+      if (
+        queuePos.length > 0 &&
+        !htm.hasTask(htm.LEVELS.COLONY, room.name, 'BUILD_CLUSTER', 'layoutPlanner')
+      ) {
+        htm.addColonyTask(
+          room.name,
+          'BUILD_CLUSTER',
+          {
+            roomName,
+            clusterId,
+            rcl: 2,
+            structureType: STRUCTURE_EXTENSION,
+            total,
+          },
+          4,
+          1500,
+          1,
+          'layoutPlanner',
+        );
+      }
+      for (const pos of queuePos) {
+        if (
+          2 <= room.controller.level &&
+          !htm.taskExistsAt(htm.LEVELS.COLONY, room.name, 'BUILD_LAYOUT_PART', {
+            x: pos.x,
+            y: pos.y,
+            structureType: STRUCTURE_EXTENSION,
+          })
+        ) {
+          htm.addColonyTask(
+            room.name,
+            'BUILD_LAYOUT_PART',
+            {
+              roomName,
+              structureType: STRUCTURE_EXTENSION,
+              x: pos.x,
+              y: pos.y,
+            },
+            5,
+            1000,
+            1,
+            'layoutPlanner',
+            {},
+            { parentTaskId: clusterId },
+          );
+        }
+      }
+    }
+
+    // Support structures around spawn
+    const around = [
+      { dx: 1, dy: 1, type: STRUCTURE_TOWER, rcl: 3 },
+      { dx: -1, dy: 1, type: STRUCTURE_LINK, rcl: 5 },
+      { dx: 1, dy: -1, type: STRUCTURE_STORAGE, rcl: 4 },
+    ];
+    for (const p of around) setCell(spawn.pos.x + p.dx, spawn.pos.y + p.dy, p.type, p.rcl);
+
+    // Containers for controller and sources
+    function openAround(pos, range) {
+      const terrain = room.getTerrain();
+      const spots = [];
+      for (let dx = -range; dx <= range; dx++) {
+        for (let dy = -range; dy <= range; dy++) {
+          const x = pos.x + dx;
+          const y = pos.y + dy;
+          if (x < 1 || x > 48 || y < 1 || y > 48) continue;
+          if (terrain.get(x, y) === TERRAIN_MASK_WALL) continue;
+          if (!layoutPlanner.isTileBlocked(roomName, x, y)) spots.push({ x, y });
+        }
+      }
+      return spots;
+    }
+
+    if (room.controller) {
+      const spots = openAround(room.controller.pos, 2);
+      for (const s of spots) {
+        if (setCell(s.x, s.y, STRUCTURE_CONTAINER, 1)) break;
+      }
+    }
+
+    const sources = room.find(FIND_SOURCES);
+    for (const src of sources) {
+      const spots = openAround(src.pos, 1);
+      for (const s of spots) {
+        if (setCell(s.x, s.y, STRUCTURE_CONTAINER, 1)) break;
+      }
+    }
+
+    // Road planning helper
+    function planRoad(from, to) {
+      if (!to) return;
+      const res = PathFinder.search(from, { pos: to, range: 1 });
+      for (const step of res.path) {
+        if (layoutPlanner.isTileBlocked(roomName, step.x, step.y)) continue;
+        if (!mem.roadMatrix[step.x]) mem.roadMatrix[step.x] = {};
+        mem.roadMatrix[step.x][step.y] = {
+          planned: true,
+          rcl: 1,
+          plannedBy: 'layoutPlanner',
+        };
+      }
+    }
+
+    planRoad(spawn.pos, room.controller && room.controller.pos);
+    for (const src of sources) planRoad(spawn.pos, src.pos);
+    const storageCell = Object.keys(mem.matrix)
+      .map((x) =>
+        Object.keys(mem.matrix[x])
+          .map((y) => ({
+            x: Number(x),
+            y: Number(y),
+            cell: mem.matrix[x][y],
+          }))
+          .filter((c) => c.cell.structureType === STRUCTURE_STORAGE)[0],
+      )
+      .filter(Boolean)[0];
+    if (storageCell) planRoad(spawn.pos, new RoomPosition(storageCell.x, storageCell.y, roomName));
+
+    // summarize structure totals for progress tracking
+    const totals = {};
+    for (const x in mem.matrix) {
+      for (const y in mem.matrix[x]) {
+        const t = mem.matrix[x][y].structureType;
+        totals[t] = (totals[t] || 0) + 1;
+      }
+    }
+    mem.status.structures = mem.status.structures || {};
+    for (const t in totals) {
+      const builtCount = room.find(FIND_STRUCTURES, { filter: s => s.structureType === t }).length;
+      mem.status.structures[t] = mem.status.structures[t] || { built: 0, total: 0 };
+      mem.status.structures[t].total = totals[t];
+      mem.status.structures[t].built = Math.min(builtCount, totals[t]);
+    }
+
+    mem.planVersion = 1;
+    if (Memory.settings && Memory.settings.debugLayoutProgress && Game.time % 1000 === 0) {
+      const matrixCount = Object.keys(mem.matrix).reduce((sum, x) => sum + Object.keys(mem.matrix[x]).length, 0);
+      const container = htm._getContainer(htm.LEVELS.COLONY, roomName);
+      const parts = container && container.tasks ? container.tasks.filter(t => t.name === 'BUILD_LAYOUT_PART').length : 0;
+      console.log(`[layoutPlanner] ${roomName}: ${matrixCount - parts}/${matrixCount} built`);
+    }
   },
 };
 

--- a/layoutVisualizer.js
+++ b/layoutVisualizer.js
@@ -12,6 +12,7 @@ function getGlyph(type) {
     [STRUCTURE_LINK]: 'K',
     [STRUCTURE_SPAWN]: 'P',
     [STRUCTURE_ROAD]: 'R',
+    [STRUCTURE_CONTAINER]: 'C',
   };
   return map[type] || '?';
 }

--- a/main.js
+++ b/main.js
@@ -179,6 +179,13 @@ scheduler.addTask({
   fn: (data) => layoutPlanner.plan(data.roomName),
 });
 
+// Periodically populate dynamic layouts for owned rooms
+scheduler.addTask('dynamicLayout', 100, () => {
+  for (const roomName in Game.rooms) {
+    layoutPlanner.populateDynamicLayout(roomName);
+  }
+}); // @codex-owner layoutPlanner @codex-trigger {"type":"interval","interval":100}
+
 // Add on-demand building manager task
 scheduler.addTask("buildInfrastructure", 0, () => {
   for (const roomName in Game.rooms) {

--- a/taskDefinitions.js
+++ b/taskDefinitions.js
@@ -44,6 +44,13 @@ taskRegistry.register('BUILD_LAYOUT_PART', {
   trigger: { type: 'condition', conditionFn: 'layoutAvailable' },
 });
 
+taskRegistry.register('BUILD_CLUSTER', {
+  owner: 'layoutPlanner',
+  priority: 4,
+  ttl: 1500,
+  trigger: { type: 'condition', conditionFn: 'layoutAvailable' },
+});
+
 taskRegistry.register('repairEmergency', {
   owner: 'buildingManager',
   priority: 1,

--- a/test/buildLayoutPartExecution.test.js
+++ b/test/buildLayoutPartExecution.test.js
@@ -1,0 +1,74 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const htm = require('../manager.htm');
+const buildingManager = require('../manager.building');
+
+global.LOOK_STRUCTURES = 'structure';
+global.LOOK_CONSTRUCTION_SITES = 'site';
+global.FIND_STRUCTURES = 1;
+global.FIND_CONSTRUCTION_SITES = 2;
+global.OK = 0;
+global.TERRAIN_MASK_WALL = 1;
+
+const STRUCTURE_EXTENSION = 'extension';
+global.STRUCTURE_EXTENSION = 'extension';
+
+describe('BUILD_LAYOUT_PART execution', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    Memory.rooms = {
+      W1N1: {
+        layout: {
+          matrix: {
+            10: { 10: { structureType: STRUCTURE_EXTENSION, rcl: 2 } },
+            12: { 10: { structureType: STRUCTURE_EXTENSION, rcl: 2 } }
+          },
+          reserved: {},
+          status: { structures: { [STRUCTURE_EXTENSION]: { built: 0, total: 2 } } }
+        }
+      }
+    };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      memory: Memory.rooms['W1N1'],
+      controller: { level: 2, my: true },
+      find: type => type === FIND_STRUCTURES ? [{ structureType: STRUCTURE_EXTENSION }] : [],
+      lookForAt: (type,x,y) =>
+        type === LOOK_STRUCTURES && x === 10 && y === 10 ? [{ structureType: STRUCTURE_EXTENSION }] : [],
+      createConstructionSite: () => OK,
+      getTerrain: () => ({ get: () => 0 })
+    };
+    global.CONTROLLER_STRUCTURES = { extension: { 2: 1 } };
+  });
+
+  it('removes task when structure already built and increments count', function() {
+    htm.addColonyTask('W1N1', 'BUILD_LAYOUT_PART', { x: 10, y: 10, structureType: STRUCTURE_EXTENSION }, 5, 100, 1, 'layoutPlanner');
+    buildingManager.processHTMTasks(Game.rooms['W1N1']);
+    const container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    expect(container.tasks.length).to.equal(0);
+    expect(Memory.rooms['W1N1'].layout.status.structures.extension.built).to.equal(1);
+  });
+
+  it('skips placement when at structure limit', function() {
+    Game.rooms['W1N1'].find = type => [];
+    Game.rooms['W1N1'].lookForAt = () => [];
+    htm.addColonyTask('W1N1', 'BUILD_LAYOUT_PART', { x: 11, y: 10, structureType: STRUCTURE_EXTENSION }, 5, 100, 1, 'layoutPlanner');
+    buildingManager.processHTMTasks(Game.rooms['W1N1']);
+    const container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    expect(container.tasks.length).to.equal(1);
+  });
+
+  it('removes task on unwalkable terrain', function() {
+    Game.rooms['W1N1'].find = () => [];
+    Game.rooms['W1N1'].lookForAt = () => [];
+    Game.rooms['W1N1'].getTerrain = () => ({ get: () => TERRAIN_MASK_WALL });
+    global.TERRAIN_MASK_WALL = 1;
+    htm.addColonyTask('W1N1', 'BUILD_LAYOUT_PART', { x: 12, y: 10, structureType: STRUCTURE_EXTENSION }, 5, 100, 1, 'layoutPlanner');
+    buildingManager.processHTMTasks(Game.rooms['W1N1']);
+    const container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    expect(container.tasks.length).to.equal(0);
+    expect(Memory.rooms['W1N1'].layout.matrix[12][10].invalid).to.be.true;
+  });
+});

--- a/test/clusterCompletion.test.js
+++ b/test/clusterCompletion.test.js
@@ -1,0 +1,36 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const htm = require('../manager.htm');
+const buildingManager = require('../manager.building');
+
+global.STRUCTURE_EXTENSION = 'extension';
+
+describe('BUILD_CLUSTER completion', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    Memory.rooms = { W1N1: { layout: { matrix: {}, reserved: {}, status: { clusters: {} } } } };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      memory: Memory.rooms['W1N1'],
+      find: () => [],
+      lookForAt: () => [],
+      controller: { level: 3, my: true },
+    };
+  });
+
+  it('marks cluster complete when subtasks done', function() {
+    htm.addColonyTask('W1N1', 'BUILD_CLUSTER', { clusterId: 'c1', total: 1 }, 4, 500, 1, 'layoutPlanner');
+    htm.addColonyTask('W1N1', 'BUILD_LAYOUT_PART', { x: 10, y: 10, structureType: STRUCTURE_EXTENSION }, 5, 100, 1, 'layoutPlanner', {}, { parentTaskId: 'c1' });
+    buildingManager.monitorClusterTasks(Game.rooms['W1N1']);
+    let container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    expect(container.tasks.find(t => t.name === 'BUILD_CLUSTER')).to.exist;
+    container.tasks = container.tasks.filter(t => t.name !== 'BUILD_LAYOUT_PART');
+    buildingManager.monitorClusterTasks(Game.rooms['W1N1']);
+    container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    const cluster = container.tasks.find(t => t.name === 'BUILD_CLUSTER');
+    expect(cluster).to.be.undefined;
+    expect(Game.rooms['W1N1'].memory.layout.status.clusters.c1.complete).to.be.true;
+  });
+});

--- a/test/constructionBlocker.test.js
+++ b/test/constructionBlocker.test.js
@@ -6,23 +6,29 @@ global.STRUCTURE_SPAWN = 'spawn';
 global.STRUCTURE_TOWER = 'tower';
 global.STRUCTURE_STORAGE = 'storage';
 global.STRUCTURE_LINK = 'link';
+global.STRUCTURE_CONTAINER = 'container';
 const globals = require('./mocks/globals');
 
 const layoutPlanner = require('../layoutPlanner');
 const blocker = require('../constructionBlocker');
+const htm = require('../manager.htm');
 
 describe('constructionBlocker.isTileBlocked', function() {
   beforeEach(function() {
     globals.resetGame();
     globals.resetMemory();
+    htm.init();
     Memory.rooms = { W1N1: {} };
     const spawn = { pos: { x: 5, y: 5, roomName: 'W1N1' } };
     Game.rooms['W1N1'] = {
       name: 'W1N1',
-      controller: { my: true },
+      controller: { my: true, level: 2, pos: { x: 20, y: 20 } },
       find: type => (type === FIND_MY_SPAWNS ? [spawn] : []),
       memory: Memory.rooms['W1N1'],
+      lookForAt: () => [],
+      getTerrain: () => ({ get: () => 0 }),
     };
+    Game.rooms['W1N1'].memory.distanceTransform = new Array(2500).fill(5);
     layoutPlanner.plan('W1N1');
   });
 

--- a/test/layoutPlanner.test.js
+++ b/test/layoutPlanner.test.js
@@ -20,10 +20,13 @@ describe('layoutPlanner.plan', function() {
     const spawn = { pos: { x: 10, y: 10, roomName: 'W1N1' } };
     Game.rooms['W1N1'] = {
       name: 'W1N1',
-      controller: { level: 1, my: true },
+      controller: { level: 1, my: true, pos: { x: 20, y: 20 } },
       find: type => (type === FIND_MY_SPAWNS ? [spawn] : []),
       memory: Memory.rooms['W1N1'],
+      lookForAt: () => [],
+      getTerrain: () => ({ get: () => 0 }),
     };
+    Game.rooms['W1N1'].memory.distanceTransform = new Array(2500).fill(5);
   });
 
   it('stores anchor and stamps', function() {

--- a/test/layoutVisualizer.test.js
+++ b/test/layoutVisualizer.test.js
@@ -6,10 +6,12 @@ global.STRUCTURE_SPAWN = 'spawn';
 global.STRUCTURE_TOWER = 'tower';
 global.STRUCTURE_STORAGE = 'storage';
 global.STRUCTURE_LINK = 'link';
+global.STRUCTURE_CONTAINER = 'container';
 const globals = require('./mocks/globals');
 
 const layoutPlanner = require('../layoutPlanner');
 const visualizer = require('../layoutVisualizer');
+const htm = require('../manager.htm');
 
 let drawn;
 
@@ -17,6 +19,7 @@ describe('layoutVisualizer.drawLayout', function() {
   beforeEach(function() {
     globals.resetGame();
     globals.resetMemory();
+    htm.init();
     global.RoomVisual = function() {};
     global.RoomVisual.prototype.text = function(...args) { drawn.push({ type: 'text', args }); };
     global.RoomVisual.prototype.rect = function(...args) { drawn.push({ type: 'rect', args }); };
@@ -25,10 +28,13 @@ describe('layoutVisualizer.drawLayout', function() {
     const spawn = { pos: { x: 5, y: 5, roomName: 'W1N1' } };
     Game.rooms['W1N1'] = {
       name: 'W1N1',
-      controller: { level: 8, my: true },
+      controller: { level: 8, my: true, pos: { x: 20, y: 20 } },
       find: type => (type === FIND_MY_SPAWNS ? [spawn] : []),
       memory: Memory.rooms['W1N1'],
+      lookForAt: () => [],
+      getTerrain: () => ({ get: () => 0 }),
     };
+    Game.rooms['W1N1'].memory.distanceTransform = new Array(2500).fill(5);
     drawn = [];
     layoutPlanner.plan('W1N1');
   });

--- a/test/mocks/globals.js
+++ b/test/mocks/globals.js
@@ -9,5 +9,10 @@ const { Memory, resetMemory } = require('./memory');
 // Attach mocks
 global.Game = Game;
 global.Memory = Memory;
+global.Room = {
+  Terrain: function () {
+    this.get = () => 0;
+  },
+};
 
 module.exports = { Game, Memory, resetGame, resetMemory };

--- a/test/populateDynamicLayout.test.js
+++ b/test/populateDynamicLayout.test.js
@@ -1,0 +1,62 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const layoutPlanner = require('../layoutPlanner');
+const htm = require('../manager.htm');
+
+global.FIND_MY_SPAWNS = 1;
+
+global.STRUCTURE_EXTENSION = 'extension';
+global.STRUCTURE_STORAGE = 'storage';
+global.STRUCTURE_TOWER = 'tower';
+global.STRUCTURE_LINK = 'link';
+global.STRUCTURE_SPAWN = 'spawn';
+global.STRUCTURE_CONTAINER = 'container';
+global.LOOK_STRUCTURES = 'structure';
+
+describe('layoutPlanner.populateDynamicLayout', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    Memory.rooms = { W1N1: { layout: { matrix: {}, reserved: {} } } };
+    const spawn = { pos: { x: 10, y: 10, roomName: 'W1N1' } };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { level: 3, my: true, pos: { x: 20, y: 20 } },
+      find: type => (type === FIND_MY_SPAWNS ? [spawn] : []),
+      memory: Memory.rooms['W1N1'],
+      lookForAt: () => [],
+      getTerrain: () => ({ get: () => 0 }),
+    };
+    Game.rooms['W1N1'].memory.distanceTransform = new Array(2500).fill(5);
+  });
+
+  it('adds cluster tasks and matrix entries', function() {
+    layoutPlanner.populateDynamicLayout('W1N1');
+    const matrix = Memory.rooms['W1N1'].layout.matrix;
+    expect(Object.keys(matrix).length).to.be.above(0);
+    const container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    const cluster = container.tasks.find(t => t.name === 'BUILD_CLUSTER');
+    const part = container.tasks.find(t => t.name === 'BUILD_LAYOUT_PART');
+    expect(cluster).to.exist;
+    expect(part).to.exist;
+    expect(part.parentTaskId).to.equal('extCluster1');
+    const firstCell = matrix[Object.keys(matrix)[0]][Object.keys(matrix[Object.keys(matrix)[0]])[0]];
+    expect(firstCell).to.have.property('planned', true);
+    expect(firstCell).to.have.property('plannedBy', 'layoutPlanner');
+    expect(firstCell).to.have.property('blockedUntil');
+  });
+
+  it('skips tasks for existing structures', function() {
+    Game.rooms['W1N1'].lookForAt = (type, x, y) =>
+      type === LOOK_STRUCTURES && x === 11 && y === 10
+        ? [{ structureType: STRUCTURE_EXTENSION }]
+        : [];
+    layoutPlanner.populateDynamicLayout('W1N1');
+    const container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    const part = container.tasks.find(
+      t => t.name === 'BUILD_LAYOUT_PART' && t.data.x === 11 && t.data.y === 10
+    );
+    expect(part).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## Summary
- compute per-structure totals in `populateDynamicLayout`
- finalize `processHTMTasks` execution for BUILD_LAYOUT_PART
- update task and memory documentation with progress fields
- test BUILD_LAYOUT_PART execution logic

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bcfb9989883279418eaccfa690904