### PR TITLE
Improve documentation and lifecycle annotations

### DIFF
--- a/Instructions.md
+++ b/Instructions.md
@@ -101,6 +101,19 @@ If a feature provides enhanced visibility:
 - Prefer dependency injection or scheduler registration for behaviors.
 - All new logic must integrate with the existing CPU tracking and logging tools.
 
+## 🏷️ Codex Metadata
+
+Source files include comment tags used by the Codex documentation tools. When
+adding new modules or tasks be sure to annotate them with the appropriate tags:
+
+- `@codex-owner moduleName` – declares ownership of a file or memory branch.
+- `@codex-task TASK_NAME` – documents an HTM task registered in `taskRegistry`.
+- `@codex-scheduler-task` – marks scheduled jobs in `main.js` or elsewhere.
+- `@codex-path Memory.path` – specifies persisted memory locations.
+
+These annotations keep the docs in sync with the codebase and help trace task
+ownership during gameplay.
+
 ---
 
 ## 🔗 Project References (Mocks, Ideas, Tools)

--- a/docs/htm.md
+++ b/docs/htm.md
@@ -63,3 +63,17 @@ Stale creep containers are purged every 50 ticks so the `Memory.htm.creeps`
 section only tracks currently living units.
 
 This flexible core allows modules to schedule work without direct coupling and provides the backbone of the hive mind.
+
+## Codex Metadata
+
+HTM handlers and task containers include Codex annotations to aid discovery.
+
+- `@codex-owner` identifies the module responsible for a task or memory branch.
+- `@codex-task` documents task names and default settings in `taskRegistry`.
+- `@codex-path` marks the memory path used by each HTM level.
+
+Example:
+
+```javascript
+htm.addColonyTask('W1N1', 'BUILD_LAYOUT_PART', {x:25,y:25,structureType:STRUCTURE_EXTENSION}, 3, 1000, 1, 'layoutPlanner'); // @codex-task BUILD_LAYOUT_PART
+```

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,6 +2,11 @@
 
 This file documents the persistent memory schema used by Tyranid Screeps.  All modules interact with memory through these namespaces.  Each module owns its branch and is responsible for migrations when the schema version changes.
 
+Codex annotations such as `@codex-owner` and `@codex-path` appear throughout this
+document and the source. They specify which module maintains a memory branch and
+where it resides. The mapping is also captured in `memory.schemas.js` for
+automated reference generation.
+
 ## Schema Versions
 
 `Memory.hive.version` tracks the current hive schema.  `memory.migrations.js`

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -82,3 +82,15 @@ Use `scheduler.listTasks()` to see current timers and next execution tick for ea
 
 `consoleDisplay` only executes when the CPU bucket exceeds 1000 thanks to its `minBucket` setting. Likewise `showScheduled` respects `Memory.settings.showTaskList` before printing.
 
+## Codex Metadata
+
+Scheduler jobs are annotated in the source with `@codex-scheduler-task` and
+`@codex-trigger` comments. These tags capture ownership and trigger details so
+documentation can be automatically generated.
+
+Example entry:
+
+```javascript
+scheduler.addTask('htmRun', 1, () => htm.run()); // @codex-owner htm @codex-trigger {"type":"interval","interval":1}
+```
+

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -167,3 +167,10 @@ taskRegistry.register('deliverEnergy', {
 ```
 
 Registered entries are exposed through `taskRegistry.registry` and may be exported to Codex docs.
+
+## Codex Metadata
+
+Tasks listed in this file are tagged in the source using `@codex-task` along with
+`@codex-owner` and other annotations. These comments allow Codex to build
+reference tables showing which module manages each task and the memory paths
+involved.

--- a/haulerLifecycle.js
+++ b/haulerLifecycle.js
@@ -1,3 +1,4 @@
+/** @codex-owner lifecyclePredictor */
 const spawnQueue = require('./manager.spawnQueue');
 const spawnManager = require('./manager.spawn');
 const _ = require('lodash');
@@ -31,6 +32,10 @@ function recordSpawnTiming(creep) {
 }
 
 const lifecycle = {
+  /**
+   * Evaluate haulers in a room and queue replacements when TTL is low.
+   * @param {Room} room Owned room to monitor.
+   */
   runRoom(room) {
     const spawns = room.find(FIND_MY_SPAWNS);
     if (spawns.length === 0) return;
@@ -89,6 +94,9 @@ const lifecycle = {
     }
   },
 
+  /**
+   * Iterate all owned rooms and process hauler lifecycle prediction.
+   */
   run() {
     for (const roomName in Game.rooms) {
       const room = Game.rooms[roomName];

--- a/hiveMind.lifecycle.js
+++ b/hiveMind.lifecycle.js
@@ -1,3 +1,4 @@
+/** @codex-owner lifecyclePredictor */
 const spawnQueue = require('./manager.spawnQueue');
 const spawnManager = require('./manager.spawn');
 const _ = require('lodash');
@@ -5,6 +6,10 @@ const _ = require('lodash');
 const BUFFER_TICKS = 10;
 
 const lifecycle = {
+  /**
+   * Evaluate miner TTLs within a room and queue replacements when necessary.
+   * @param {Room} room Owned room to monitor.
+   */
   runRoom(room) {
     const spawns = room.find(FIND_MY_SPAWNS);
     if (spawns.length === 0) return;
@@ -94,6 +99,9 @@ const lifecycle = {
     }
   },
 
+  /**
+   * Iterate all owned rooms and process miner lifecycle prediction.
+   */
   run() {
     for (const roomName in Game.rooms) {
       const room = Game.rooms[roomName];

--- a/manager.building.js
+++ b/manager.building.js
@@ -38,6 +38,10 @@ function getOpenSpots(pos, range) {
 }
 
 const buildingManager = {
+  /**
+   * Store potential container spots around each source for quick reference.
+   * @param {Room} room Room to analyze.
+   */
   cacheBuildableAreas: function (room) {
     const sources = room.find(FIND_SOURCES);
     const buildableAreas = {};
@@ -60,6 +64,11 @@ const buildingManager = {
     room.memory.lastCacheUpdate = Game.time;
   },
 
+  /**
+   * Determine if the buildable area cache should be refreshed.
+   * @param {Room} room Target room.
+   * @returns {boolean} True when cache needs update.
+   */
   shouldUpdateCache: function (room) {
     if (!room.memory.buildableAreas) {
       return true; // Initial cache creation
@@ -82,6 +91,11 @@ const buildingManager = {
     return false;
   },
 
+  /**
+   * Execute construction related logic for an owned room.
+   * Places sites, processes HTM tasks and manages cache.
+   * @param {Room} room Room being processed.
+   */
   buildInfrastructure: function (room) {
     this.processHTMTasks(room);
     this.monitorClusterTasks(room);
@@ -105,6 +119,10 @@ const buildingManager = {
     this.executeLayout(room);
   },
 
+  /**
+   * Generate and sort the building queue based on construction sites present.
+   * @param {Room} room Room being processed.
+   */
   manageBuildingQueue: function (room) {
     const buildingQueue = [];
     const prevLength = (room.memory.buildingQueue || []).length;

--- a/manager.hiveGaze.js
+++ b/manager.hiveGaze.js
@@ -9,7 +9,12 @@ const { getRandomTyranidQuote } = require('./utils.quotes');
  * HiveGaze explores exits and queues scout tasks.
  * @codex-owner hiveGaze
  */
+// Cache result for the current tick to avoid repeated terrain scans
 function scoreTerrain(roomName) {
+  const mem = Memory.rooms[roomName] || {};
+  if (mem.terrainScore && mem.terrainScore.tick === Game.time) {
+    return mem.terrainScore.score;
+  }
   const terrain = Game.map.getRoomTerrain(roomName);
   let open = 0;
   for (let x = 0; x < 50; x++) {
@@ -17,6 +22,8 @@ function scoreTerrain(roomName) {
       if (terrain.get(x, y) !== TERRAIN_MASK_WALL) open++;
     }
   }
+  if (!Memory.rooms[roomName]) Memory.rooms[roomName] = {};
+  Memory.rooms[roomName].terrainScore = { score: open, tick: Game.time };
   return open;
 }
 


### PR DESCRIPTION
## Summary
- document Codex metadata usage in project guidelines
- clarify memory layout docs and HTM metadata examples
- explain scheduler task tags
- highlight task registry metadata
- annotate lifecycle predictors and building manager functions
- cache terrain scores in `hiveGaze`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be1b5a31c8327ad1e0c89cf0cffb7