### PR TITLE
Implement tower manager and base distributor

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -33,6 +33,14 @@ Memory.hive = {
 ```
 
 `manager.memory.js` ensures this layout exists via `initializeHiveMemory(clusterId, colonyId)`.
+The `meta` section may track additional data. Base distributors store their
+assigned creep name here:
+
+```javascript
+Memory.hive.clusters['W1N1'].colonies['W1N1'].meta = {
+  distributor: 'D1'
+};
+```
 
 ## Module Ownership
 
@@ -222,6 +230,8 @@ Memory.settings = {
   debugHiveGaze: false,
   debugBuilding: false,      // log build results and draw visual overlays
   debugLayoutProgress: false // log layout progress every 1000 ticks
+  debugVisuals: false,       // draw role and tower debug icons
+  enableTowerRepairs: true   // allow towers to repair when bucket is high
 };
 ```
 

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -28,6 +28,8 @@ Haulers remain governed by the energy demand module.
   Haulers also relocate to an open tile near the spawn after depositing when
   the drop location is within the restricted area so they never idle on those
   reserved spots.
+- **Base Distributor** – Small courier active once storage is built. Pulls energy
+  only from storage and keeps spawns, extensions and towers supplied.
 - **Remote Miners** – Travel to pre-assigned coordinates in remote rooms and
   harvest until death. They keep mining positions reserved via memory.
 - **Reservists** – Lightweight creeps that reserve a remote controller and sign

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -58,6 +58,7 @@ taskRegistry.register('upgradeController', {
 | `spawnHauler`    | `spawnManager`   | 1               | Request a hauler creep.         |
 | `upgradeController` | `hivemind.spawn` | 3             | Encourage controller upgrades.  |
 | `deliverEnergy`  | `energyRequests` | 2               | Hauler delivery to a structure. |
+| `DELIVER_BASE_ENERGY` | `role.baseDistributor` | 2 | Distributor delivery to core structures. |
 | `defendRoom`     | `hivemind.spawn` | 1               | Spawn defenders on hostiles.    |
 | `spawnBootstrap` | `spawnManager`   | 0               | Emergency worker when none exist. |
 | `acquireMiningData` | `roomManager` | 2 | Rescan room to rebuild mining positions. |
@@ -167,6 +168,10 @@ taskRegistry.register('deliverEnergy', {
 ```
 
 Registered entries are exposed through `taskRegistry.registry` and may be exported to Codex docs.
+
+## Scheduler Tasks
+
+Additional logic runs on fixed intervals via the scheduler. `runTowers` executes every three ticks to operate defensive towers.
 
 ## Codex Metadata
 

--- a/manager.dna.js
+++ b/manager.dna.js
@@ -19,6 +19,8 @@ function getBodyParts(role, room, panic = false) {
       return buildMiner(available, panic);
     case "hauler":
       return buildHauler(available, panic);
+    case "baseDistributor":
+      return buildBaseDistributor();
     case "builder":
       return buildWorker(available, panic);
     case "upgrader":
@@ -66,6 +68,10 @@ function buildWorker(energy, panic) {
     body.push(WORK, CARRY, MOVE);
   }
   return body;
+}
+
+function buildBaseDistributor() {
+  return [CARRY, CARRY, MOVE, MOVE];
 }
 
 function buildAllPurpose(energy, panic) {

--- a/manager.towers.js
+++ b/manager.towers.js
@@ -1,0 +1,72 @@
+/**
+ * Operates room towers for defense and maintenance.
+ * @codex-owner towers
+ * @codex-scheduler-task runTowers
+ */
+const statsConsole = require('console.console');
+
+const towers = {
+  run() {
+    for (const roomName in Game.rooms) {
+      const room = Game.rooms[roomName];
+      if (!room.controller || !room.controller.my) continue;
+      const towers = room.find(FIND_MY_STRUCTURES, {
+        filter: s => s.structureType === STRUCTURE_TOWER,
+      });
+      if (!towers.length) continue;
+
+      const hostiles = room.find(FIND_HOSTILE_CREEPS);
+      for (const tower of towers) {
+        this.runTower(tower, hostiles);
+      }
+    }
+  },
+
+  runTower(tower, hostiles) {
+    const room = tower.room;
+    const debug = Memory.settings && Memory.settings.debugVisuals;
+    const vis = debug ? new RoomVisual(room.name) : null;
+
+    if (hostiles.length) {
+      const target = tower.pos.findClosestByRange(hostiles);
+      const res = tower.attack(target);
+      if (vis && res === OK) vis.text('⚔️', tower.pos.x, tower.pos.y - 1, { color: 'red', font: 0.8 });
+      return;
+    }
+
+    const injured = room.find(FIND_MY_CREEPS, { filter: c => c.hits < c.hitsMax });
+    if (injured.length) {
+      const target = tower.pos.findClosestByRange(injured);
+      const res = tower.heal(target);
+      if (vis && res === OK) vis.text('💊', tower.pos.x, tower.pos.y - 1, { color: 'green', font: 0.8 });
+      return;
+    }
+
+    if (!Memory.settings.enableTowerRepairs || Game.cpu.bucket < 8000) return;
+
+    const repairTargets = room.find(FIND_STRUCTURES, {
+      filter: s => {
+        if (s.hits >= s.hitsMax) return false;
+        if (s.structureType === STRUCTURE_ROAD) {
+          return s.hits / s.hitsMax < 0.8;
+        }
+        if (s.structureType === STRUCTURE_CONTAINER) {
+          return s.hits / s.hitsMax < 0.5;
+        }
+        if (s.structureType === STRUCTURE_RAMPART) {
+          if (hostiles.length) return false;
+          return s.hits < 5000;
+        }
+        return false;
+      },
+    });
+
+    if (repairTargets.length) {
+      const target = tower.pos.findClosestByRange(repairTargets);
+      const res = tower.repair(target);
+      if (vis && res === OK) vis.text('🔧', tower.pos.x, tower.pos.y - 1, { color: 'yellow', font: 0.8 });
+    }
+  },
+};
+
+module.exports = towers;

--- a/role.baseDistributor.js
+++ b/role.baseDistributor.js
@@ -1,0 +1,61 @@
+/**
+ * Lightweight hauler operating within the base.
+ * @codex-owner role.baseDistributor
+ * @codex-trigger onStorageBuilt
+ * @codex-task DELIVER_BASE_ENERGY
+ */
+const movementUtils = require('./utils.movement');
+const htm = require('./manager.htm');
+
+const roleBaseDistributor = {
+  run(creep) {
+    if (!creep.room.storage) return;
+
+    if (creep.store[RESOURCE_ENERGY] === 0) {
+      const res = creep.withdraw(creep.room.storage, RESOURCE_ENERGY);
+      if (res === ERR_NOT_IN_RANGE) creep.travelTo(creep.room.storage);
+      return;
+    }
+
+    let target = null;
+    const container = htm._getContainer(htm.LEVELS.CREEP, creep.name);
+    if (container && container.tasks) {
+      const task = container.tasks.find(t => t.name === 'DELIVER_BASE_ENERGY');
+      if (task) {
+        target = Game.getObjectById(task.data.id);
+        if (!target) {
+          container.tasks.splice(container.tasks.indexOf(task), 1);
+        } else if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+          creep.travelTo(target);
+          return;
+        } else {
+          container.tasks.splice(container.tasks.indexOf(task), 1);
+          return;
+        }
+      }
+    }
+
+    if (!target) {
+      target = creep.pos.findClosestByPath(FIND_MY_STRUCTURES, {
+        filter: s =>
+          ((s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) &&
+            s.store.getFreeCapacity(RESOURCE_ENERGY) > 0) ||
+          (s.structureType === STRUCTURE_TOWER && s.store.getFreeCapacity(RESOURCE_ENERGY) > s.store.getCapacity(RESOURCE_ENERGY) / 2),
+      });
+      if (target) {
+        if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+          creep.travelTo(target);
+        }
+        if (Memory.settings && Memory.settings.debugVisuals) {
+          new RoomVisual(creep.room.name).text('⚡', creep.pos.x, creep.pos.y - 0.5, { color: 'yellow', font: 0.8 });
+        }
+        return;
+      }
+    }
+
+    const idle = movementUtils.findIdlePosition(creep.room);
+    if (idle && !creep.pos.isEqualTo(idle)) creep.travelTo(idle, { range: 0 });
+  },
+};
+
+module.exports = roleBaseDistributor;

--- a/taskDefinitions.js
+++ b/taskDefinitions.js
@@ -72,6 +72,12 @@ taskRegistry.register('deliverEnergy', {
   trigger: { type: 'condition', conditionFn: 'structureNeedsEnergy' },
 });
 
+taskRegistry.register('DELIVER_BASE_ENERGY', {
+  owner: 'role.baseDistributor',
+  priority: 2,
+  ttl: 30,
+});
+
 taskRegistry.register('defendRoom', {
   owner: 'hivemind.spawn',
   priority: 1,

--- a/test/spawnBaseDistributor.test.js
+++ b/test/spawnBaseDistributor.test.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const spawnManager = require('../manager.spawn');
+const spawnQueue = require('../manager.spawnQueue');
+
+global._ = require('lodash');
+
+global.FIND_MY_SPAWNS = 1;
+
+describe('spawnManager base distributor', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory({ hive: { clusters: { W1N1: { colonies: { W1N1: { meta:{} } } } } }, stats:{ logs: [] } });
+    spawnQueue.queue = [];
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      storage: {},
+      find: type => (type === FIND_MY_SPAWNS ? [ { id:'s1', pos:{}, room:{ name:'W1N1' } } ] : []),
+    };
+    Game.creeps = {};
+  });
+
+  it('queues distributor when none present', function() {
+    spawnManager.checkStorageAndSpawnBaseDistributor(Game.rooms['W1N1']);
+    expect(spawnQueue.queue.length).to.equal(1);
+    expect(spawnQueue.queue[0].category).to.equal('baseDistributor');
+  });
+});

--- a/test/towerManager.test.js
+++ b/test/towerManager.test.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const towerManager = require('../manager.towers');
+
+global.FIND_MY_STRUCTURES = 1;
+global.FIND_HOSTILE_CREEPS = 2;
+global.FIND_MY_CREEPS = 3;
+global.FIND_STRUCTURES = 4;
+
+global.STRUCTURE_TOWER = 'tower';
+global.STRUCTURE_ROAD = 'road';
+global.STRUCTURE_CONTAINER = 'container';
+global.STRUCTURE_RAMPART = 'rampart';
+
+global.OK = 0;
+
+describe('towerManager', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory({ settings: { enableTowerRepairs: true } });
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { my: true },
+      find(type) {
+        if (type === FIND_MY_STRUCTURES) return [tower];
+        if (type === FIND_HOSTILE_CREEPS) return [hostile];
+        if (type === FIND_MY_CREEPS) return [];
+        if (type === FIND_STRUCTURES) return [];
+        return [];
+      },
+    };
+  });
+
+  let tower;
+  let hostile;
+
+  it('attacks hostile creeps first', function() {
+    hostile = { id: 'h1' };
+    let attacked = false;
+    tower = {
+      room: Game.rooms['W1N1'],
+      pos: { findClosestByRange: () => hostile, x: 25, y:25 },
+      attack: () => { attacked = true; return OK; },
+      heal: () => OK,
+      repair: () => OK,
+    };
+    towerManager.run();
+    expect(attacked).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- add tower defense manager with repair logic
- implement baseDistributor role for internal energy hauling
- spawn manager support for baseDistributor and new DNA option
- schedule new tasks `runTowers` and distributor spawn check
- document new memory settings and tasks
- add unit tests for tower manager and distributor spawning

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bee69b56c83278b909f2f8547df2e