### PR TITLE
Fix spawn manager optional chaining syntax error

### DIFF
--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -113,8 +113,13 @@ const calculateEffectiveEnergyCapacity = (room) => {
  * @returns {number} Required miner count for the source.
  */
 function calculateRequiredMiners(room, source) {
+  // Safely access mining position data without optional chaining to avoid
+  // compatibility issues with older runtimes
   const sourceMem =
-    Memory.rooms?.[room.name]?.miningPositions?.[source.id];
+    Memory.rooms &&
+    Memory.rooms[room.name] &&
+    Memory.rooms[room.name].miningPositions &&
+    Memory.rooms[room.name].miningPositions[source.id];
   if (!sourceMem) return 0;
 
   const availablePositions = Object.keys(sourceMem.positions || {}).length;

--- a/test/calculateRequiredMiners.test.js
+++ b/test/calculateRequiredMiners.test.js
@@ -1,0 +1,47 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+global.WORK = 'work';
+global.MOVE = 'move';
+global.HARVEST_POWER = 2;
+// minimal costs so dna.getBodyParts works consistently
+global.BODYPART_COST = { work: 100, move: 50 };
+global.TOP = 1;
+global.TOP_RIGHT = 2;
+global.RIGHT = 3;
+global.BOTTOM_RIGHT = 4;
+global.BOTTOM = 5;
+global.BOTTOM_LEFT = 6;
+global.LEFT = 7;
+global.TOP_LEFT = 8;
+global.TERRAIN_MASK_WALL = 1;
+global.OBSTACLE_OBJECT_TYPES = [];
+
+const spawnManager = require('../manager.spawn');
+
+describe('spawnManager.calculateRequiredMiners', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory();
+    Game.rooms['W1N1'] = { name: 'W1N1', energyCapacityAvailable: 550 };
+  });
+
+  it('returns zero when no miningPositions memory', function () {
+    const source = { id: 's1' };
+    const count = spawnManager.calculateRequiredMiners(Game.rooms['W1N1'], source);
+    expect(count).to.equal(0);
+  });
+
+  it('calculates miners based on positions and work parts', function () {
+    Memory.rooms = {
+      W1N1: {
+        miningPositions: { s1: { positions: { a: {}, b: {} } } },
+      },
+    };
+    const source = { id: 's1' };
+    const count = spawnManager.calculateRequiredMiners(Game.rooms['W1N1'], source);
+    // With 5 WORK parts (550 energy room) energyPerTick = 10
+    // requirement becomes 1 miner given two available positions
+    expect(count).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- access mining position memory without optional chaining for compatibility
- cover calculateRequiredMiners with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d86c0fbe88327980f7b0f323751d6