### PR TITLE
Fix undefined spawn bug in room scan

### DIFF
--- a/manager.room.js
+++ b/manager.room.js
@@ -46,9 +46,12 @@ const roomManager = {
         distanceFromSpawn = result.path ? result.path.length : 0;
       }
 
-      potential.sort((a, b) =>
-        spawn.pos.getRangeTo(a.x, a.y) - spawn.pos.getRangeTo(b.x, b.y),
-      );
+      // Sort potential positions by proximity to spawn when available
+      if (spawn) {
+        potential.sort(
+          (a, b) => spawn.pos.getRangeTo(a.x, a.y) - spawn.pos.getRangeTo(b.x, b.y),
+        );
+      }
 
       const containers = room.find(FIND_STRUCTURES, {
         filter: s => s.structureType === STRUCTURE_CONTAINER && s.pos.inRangeTo(source, 1),

--- a/test/roomScanContainer.test.js
+++ b/test/roomScanContainer.test.js
@@ -60,4 +60,21 @@ describe('roomManager.scanRoom container placement', function() {
     const pos = Memory.rooms.W1N1.miningPositions.s1.positions.best1;
     expect(pos).to.deep.equal({ x: 11, y: 10, roomName: 'W1N1', reserved: false });
   });
+
+  it('handles rooms without spawns gracefully', function() {
+    Game.rooms['W1N1'].find = function(type) {
+      if (type === FIND_SOURCES) {
+        return [{ id: 's1', pos: { x: 10, y: 10 } }];
+      }
+      if (type === FIND_MY_SPAWNS) {
+        return [];
+      }
+      if (type === FIND_STRUCTURES) return [];
+      return [];
+    };
+
+    expect(() => roomManager.scanRoom(Game.rooms['W1N1'])).to.not.throw();
+    const pos = Memory.rooms.W1N1.miningPositions.s1.positions.best1;
+    expect(pos).to.deep.equal({ x: 11, y: 10, roomName: 'W1N1', reserved: false });
+  });
 });


### PR DESCRIPTION
## Summary
- prevent crash when scanning rooms without spawns
- update room scan test to cover no-spawn scenario

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d8bd50ca88327a310002d2c0f8896