### PR TITLE
Add starter couple spawn task

### DIFF
--- a/docs/roles.md
+++ b/docs/roles.md
@@ -11,8 +11,10 @@ Haulers remain governed by the energy demand module.
    source is saturated. Mining power is based on the miner DNA returned by
    `manager.dna`. The required miner count is calculated from the available
    positions and WORK parts – typically a single 5&nbsp;WORK miner can fully
-   saturate a standard source. Miners with at least five WORK parts automatically
-   relocate onto the nearby container so they can empty the source without moving.
+   saturate a standard source. The miner count for each source never exceeds the
+   number of available spots and is capped at five miners. Miners with at least
+   five WORK parts automatically relocate onto the nearby container so they can
+   empty the source without moving.
  - **Upgraders** – Simplified workers that gather the closest available energy
    on their own and then move within range&nbsp;3 of the controller to upgrade
    it. They no longer rely on assigned containers or hauler deliveries but

--- a/docs/spawnQueue.md
+++ b/docs/spawnQueue.md
@@ -46,6 +46,13 @@ In panic situations the HiveMind may purge all pending requests for a room. Use
 `spawnQueue.clearRoom(roomName)` to remove every queued entry belonging to that
 room.
 
+### Subtasks
+
+HTM tasks may schedule multiple spawn requests as subtasks. For example
+`spawnStarterCouple` spawns a miner and then a hauler. Each subtask results in a
+normal spawn queue entry but the parent task is only completed once all
+subtasks have finished.
+
 ### Memory Layout
 
 @codex-owner spawnQueue

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -61,6 +61,7 @@ taskRegistry.register('upgradeController', {
 | `DELIVER_BASE_ENERGY` | `role.baseDistributor` | 2 | Distributor delivery to core structures. |
 | `defendRoom`     | `hivemind.spawn` | 1               | Spawn defenders on hostiles.    |
 | `spawnBootstrap` | `spawnManager`   | 0               | Emergency worker when none exist. |
+| `spawnStarterCouple` | `spawnManager`   | 0 | Spawn a miner then a hauler as subtasks. |
 | `acquireMiningData` | `roomManager` | 2 | Rescan room to rebuild mining positions. |
 | `buildSite` | `buildingManager` | 1 | Assign builders to a construction site. |
 | `repairEmergency` | `buildingManager` | 1 | Repair structures close to decay. |
@@ -77,6 +78,7 @@ taskRegistry.register('upgradeController', {
 | `spawnMiner`      | condition via `hive.roles` evaluation          |
 | `spawnHauler`     | condition via energy demand analysis           |
 | `spawnBootstrap`  | condition when no workers are present          |
+| `spawnStarterCouple` | condition via `hive.roles` evaluation |
 | `upgradeController` | event `roleUpdate` or energy surplus check    |
 | `defendRoom`      | event `hostilesDetected`                       |
 | `deliverEnergy`   | condition when structure free capacity > 0     |

--- a/taskDefinitions.js
+++ b/taskDefinitions.js
@@ -23,6 +23,12 @@ taskRegistry.register('spawnBootstrap', {
   trigger: { type: 'condition', conditionFn: 'hivemind.spawn.bootstrap' },
 });
 
+taskRegistry.register('spawnStarterCouple', {
+  owner: 'spawnManager',
+  priority: 0,
+  ttl: 50,
+});
+
 taskRegistry.register('acquireMiningData', {
   owner: 'roomManager',
   priority: 2,

--- a/test/roleEvaluation.test.js
+++ b/test/roleEvaluation.test.js
@@ -54,7 +54,9 @@ describe('hive.roles evaluateRoom', function() {
   it('queues miners for unsaturated source', function() {
     roles.evaluateRoom(Game.rooms['W1N1']);
     const tasks = Memory.htm.colonies['W1N1'].tasks;
-    const t = tasks.find(x => x.name === 'spawnMiner');
+    const miner = tasks.find(x => x.name === 'spawnMiner');
+    const couple = tasks.find(x => x.name === 'spawnStarterCouple');
+    const t = miner || couple;
     expect(t).to.exist;
     expect(t.amount).to.equal(3);
   });

--- a/test/spawnStarterCouple.test.js
+++ b/test/spawnStarterCouple.test.js
@@ -1,0 +1,57 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+global.TOP = 1;
+global.TOP_RIGHT = 2;
+global.RIGHT = 3;
+global.BOTTOM_RIGHT = 4;
+global.BOTTOM = 5;
+global.BOTTOM_LEFT = 6;
+global.LEFT = 7;
+global.TOP_LEFT = 8;
+global.WORK = 'work';
+global.CARRY = 'carry';
+global.MOVE = 'move';
+global.BODYPART_COST = { work: 100, carry: 50, move: 50 };
+global.FIND_MY_CONSTRUCTION_SITES = 1;
+global.STRUCTURE_EXTENSION = 'extension';
+global.EXTENSION_ENERGY_CAPACITY = { 1: 50 };
+global.FIND_MY_SPAWNS = 2;
+
+const htm = require('../manager.htm');
+const spawnManager = require('../manager.spawn');
+
+global._ = require('lodash');
+
+describe('spawnStarterCouple subtasks', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    Memory.stats = { logs: [], logCounts: {} };
+    htm.init();
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      find: type => (type === FIND_MY_SPAWNS ? [{ id: 's1', spawning: false, room: { name: 'W1N1' } }] : []),
+      energyCapacityAvailable: 300,
+    };
+    htm.addColonyTask('W1N1', spawnManager.TASK_STARTER_COUPLE, {}, 0, 50, 1, 'spawnManager');
+  });
+
+  it('creates miner then hauler subtasks and removes parent', function() {
+    spawnManager.processHTMTasks(Game.rooms['W1N1']);
+    let container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    expect(container.tasks.some(t => t.name === 'spawnMiner')).to.be.true;
+
+    // simulate miner completed
+    container.tasks = container.tasks.filter(t => t.name !== 'spawnMiner');
+    spawnManager.processHTMTasks(Game.rooms['W1N1']);
+    container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    expect(container.tasks.find(t => t.name === spawnManager.TASK_STARTER_COUPLE)).to.exist;
+
+    // simulate hauler completed
+    container.tasks = container.tasks.filter(t => t.name !== 'spawnHauler');
+    spawnManager.processHTMTasks(Game.rooms['W1N1']);
+    container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
+    expect(container.tasks.find(t => t.name === spawnManager.TASK_STARTER_COUPLE)).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## Summary
- implement TASK_STARTER_COUPLE for sequential miner+hauler spawning
- handle new task in spawn manager and hive roles
- document in spawn queue and tasks docs
- update hivemind spawning logic for RCL1
- include new unit tests
- dynamically cap miners per source at available positions (max 5)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684da0638c688327862c8af8a9551e1c