### PR TITLE
Ensure room layout planning triggered automatically

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -63,6 +63,7 @@ The main loop registers several core jobs which drive the colony:
 | `clearMemory`        | 100 ticks      | `main`             | Removes dead creep memory. |
 | `updateHUD`          | 5 ticks        | `main`             | Draws HUD visuals. |
 | `layoutPlanningInit` | event `roomOwnershipEstablished` (once) | `layoutPlanner` | Initialize base layout when a room is claimed. |
+| `ensureLayoutPlan` | 20 ticks | `layoutPlanner` | Verify each owned room has a layout plan. |
 | `dynamicLayout` | 100 ticks | `layoutPlanner` | Populate dynamic layout and queue cluster tasks. |
 | `buildInfrastructure`| every tick     | `buildingManager`  | Places construction sites when needed. |
 | `hivemind`           | 1 tick         | `hivemind`         | Evaluates strategy and queues HTM tasks. |

--- a/layoutPlanner.js
+++ b/layoutPlanner.js
@@ -67,6 +67,19 @@ const layoutPlanner = {
   },
 
   /**
+   * Ensure a layout plan exists for the room. Creates one if missing.
+   * @param {string} roomName
+   */
+  ensurePlan(roomName) {
+    const room = Game.rooms[roomName];
+    if (!room || !room.controller || !room.controller.my) return;
+    const mem = Memory.rooms[roomName];
+    if (!mem || !mem.layout || mem.layout.planVersion !== 1) {
+      this.plan(roomName);
+    }
+  },
+
+  /**
    * Generate dynamic layout positions based on terrain and spawn anchor.
    * @param {string} roomName
    * @codex-owner layoutPlanner

--- a/main.js
+++ b/main.js
@@ -189,6 +189,13 @@ scheduler.addTask({
   fn: (data) => layoutPlanner.plan(data.roomName),
 });
 
+// Ensure each owned room has a layout plan
+scheduler.addTask('ensureLayoutPlan', 20, () => {
+  for (const roomName in Game.rooms) {
+    layoutPlanner.ensurePlan(roomName);
+  }
+}); // @codex-owner layoutPlanner @codex-trigger {"type":"interval","interval":20}
+
 // Periodically populate dynamic layouts for owned rooms
 scheduler.addTask('dynamicLayout', 100, () => {
   for (const roomName in Game.rooms) {

--- a/test/ensureLayoutPlan.test.js
+++ b/test/ensureLayoutPlan.test.js
@@ -1,0 +1,45 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+const layoutPlanner = require('../layoutPlanner');
+const htm = require('../manager.htm');
+
+// mock constants
+global.FIND_MY_SPAWNS = 1;
+global.STRUCTURE_EXTENSION = 'extension';
+global.STRUCTURE_SPAWN = 'spawn';
+global.STRUCTURE_TOWER = 'tower';
+global.STRUCTURE_STORAGE = 'storage';
+global.STRUCTURE_LINK = 'link';
+
+describe('layoutPlanner.ensurePlan', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    htm.init();
+    Memory.rooms = { W1N1: {} };
+    const spawn = { pos: { x: 10, y: 10, roomName: 'W1N1' } };
+    Game.rooms['W1N1'] = {
+      name: 'W1N1',
+      controller: { level: 3, my: true, pos: { x: 20, y: 20 } },
+      find: type => (type === FIND_MY_SPAWNS ? [spawn] : []),
+      memory: Memory.rooms['W1N1'],
+      lookForAt: () => [],
+      getTerrain: () => ({ get: () => 0 }),
+    };
+    Game.rooms['W1N1'].memory.distanceTransform = new Array(2500).fill(5);
+  });
+
+  it('creates a plan when missing', function() {
+    layoutPlanner.ensurePlan('W1N1');
+    expect(Memory.rooms['W1N1'].layout).to.exist;
+    expect(Memory.rooms['W1N1'].layout.planVersion).to.equal(1);
+  });
+
+  it('does not overwrite an existing plan', function() {
+    layoutPlanner.plan('W1N1');
+    const before = JSON.stringify(Memory.rooms['W1N1'].layout);
+    Game.time++;
+    layoutPlanner.ensurePlan('W1N1');
+    expect(JSON.stringify(Memory.rooms['W1N1'].layout)).to.equal(before);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ensurePlan` helper to layoutPlanner
- schedule `ensureLayoutPlan` job in main loop
- document new scheduler task
- test ensurePlan behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684da6c34a008327ac972413a5327e1c