### PR TITLE
Add memory cleanup utilities

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -233,6 +233,8 @@ Memory.demand.routes[routeId] = {
 
 Records temporary energy reservations for pickup targets. Each key is a resource or
 structure id and the value is the amount currently reserved by haulers.
+`memoryManager.cleanUpEnergyReserves` periodically removes entries when the
+target no longer exists or contains no energy.
 
 ### Runtime Settings
 

--- a/docs/spawnQueue.md
+++ b/docs/spawnQueue.md
@@ -63,3 +63,6 @@ subtasks have finished. Queue sorting first compares the parent task tick and th
 `Memory.spawnQueue` is an array containing the request objects shown above.
 `Memory.nextSpawnRequestId` increments each tick to guarantee unique ids.
 Requests are removed once the spawn succeeds or they are explicitly cleared.
+`spawnQueue.cleanUp(maxAge)` can be used to prune entries older than `maxAge`
+ticks to prevent unbounded growth.
+

--- a/main.js
+++ b/main.js
@@ -16,6 +16,7 @@ const distanceTransform = require("algorithm.distanceTransform");
 const hudManager = require("manager.hud");
 const stampManager = require("manager.stamps");
 const memoryManager = require("manager.memory");
+const spawnQueue = require("manager.spawnQueue");
 const hiveTravel = require("manager.hiveTravel");
 const towerManager = require('./manager.towers');
 const scheduler = require("scheduler");
@@ -317,6 +318,15 @@ scheduler.addTask('verifyMiningReservations', 10, () => {
   // Also clean up legacy reservation entries
   memoryManager.cleanUpReservedPositions();
 }); // @codex-owner memoryManager @codex-trigger {"type":"interval","interval":10}
+
+// Periodically prune stale energy reservations and spawn requests
+scheduler.addTask('cleanEnergyReserves', 50, () => {
+  memoryManager.cleanUpEnergyReserves();
+}); // @codex-owner memoryManager @codex-trigger {"type":"interval","interval":50}
+
+scheduler.addTask('pruneSpawnQueue', 50, () => {
+  spawnQueue.cleanUp();
+}); // @codex-owner spawnQueue @codex-trigger {"type":"interval","interval":50}
 
 scheduler.addTask('runTowers', 3, () => {
   towerManager.run();

--- a/manager.memory.js
+++ b/manager.memory.js
@@ -120,6 +120,21 @@ const memoryManager = {
   },
 
   /**
+   * Remove stale entries from Memory.energyReserves.
+   * Objects that no longer exist or contain no energy are cleared.
+   */
+  cleanUpEnergyReserves() {
+    if (!Memory.energyReserves) return;
+    for (const id in Memory.energyReserves) {
+      const obj = Game.getObjectById(id);
+      const hasEnergy = obj && ((obj.amount || (obj.store && obj.store[RESOURCE_ENERGY])) > 0);
+      if (!obj || !hasEnergy) {
+        delete Memory.energyReserves[id];
+      }
+    }
+  },
+
+  /**
    * Assigns an available mining position to a creep.
    *
    * @param {Object} creepMemory - The creep's memory object.

--- a/manager.spawnQueue.js
+++ b/manager.spawnQueue.js
@@ -218,6 +218,23 @@ const spawnQueue = {
       }
     }
   },
+
+  /**
+   * Remove spawn requests older than the provided age in ticks.
+   * @param {number} maxAge - Maximum age to keep (default 1000).
+   */
+  cleanUp(maxAge = 1000) {
+    const cutoff = Game.time - maxAge;
+    const before = this.queue.length;
+    this.queue = this.queue.filter((req) => {
+      const created = parseInt(req.requestId.split('-')[0], 10);
+      return created >= cutoff;
+    });
+    const removed = before - this.queue.length;
+    if (removed > 0) {
+      logger.log('spawnQueue', `Pruned ${removed} stale spawn requests`, 2);
+    }
+  },
 };
 
 module.exports = spawnQueue;

--- a/test/energyReserveCleanup.test.js
+++ b/test/energyReserveCleanup.test.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const memoryManager = require('../manager.memory');
+
+global.RESOURCE_ENERGY = 'energy';
+
+describe('cleanUpEnergyReserves', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    Memory.energyReserves = { old: 20, empty: 5, good: 10 };
+    Game.getObjectById = id => {
+      if (id === 'good') return { store: { [RESOURCE_ENERGY]: 50 } };
+      if (id === 'empty') return { store: { [RESOURCE_ENERGY]: 0 } };
+      return null;
+    };
+  });
+
+  it('removes missing or empty entries', function() {
+    memoryManager.cleanUpEnergyReserves();
+    expect(Memory.energyReserves).to.deep.equal({ good: 10 });
+  });
+});

--- a/test/spawnQueueCleanup.test.js
+++ b/test/spawnQueueCleanup.test.js
@@ -1,0 +1,26 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+const spawnQueue = require('../manager.spawnQueue');
+
+global.WORK = 'work';
+global.MOVE = 'move';
+
+describe('spawnQueue.cleanUp', function() {
+  beforeEach(function() {
+    globals.resetGame();
+    globals.resetMemory();
+    spawnQueue.queue = [];
+    Memory.nextSpawnRequestId = 0;
+    Game.time = 100;
+    spawnQueue.addToQueue('miner', 'W1N1', [WORK, MOVE], { role: 'miner' }, 's1');
+    Game.time = 1200;
+    spawnQueue.addToQueue('hauler', 'W1N1', [MOVE], { role: 'hauler' }, 's1');
+  });
+
+  it('removes entries older than maxAge', function() {
+    spawnQueue.cleanUp(1000);
+    expect(spawnQueue.queue.length).to.equal(1);
+    expect(spawnQueue.queue[0].memory.role).to.equal('hauler');
+  });
+});


### PR DESCRIPTION
## Summary
- clean up stale energy reservations via `memoryManager.cleanUpEnergyReserves`
- prune old spawn queue entries with `spawnQueue.cleanUp`
- schedule cleanup tasks in `main`
- document cleanup in `docs/memory.md` and `docs/spawnQueue.md`
- add tests for the new cleanup functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684def2800e883279c2a3fecece8368b