### PR TITLE
Fix reservist controller signing and add lodash imports

### DIFF
--- a/manager.spawn.js
+++ b/manager.spawn.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const memoryManager = require("manager.memory");
 const dna = require("./manager.dna");
 const spawnQueue = require("manager.spawnQueue");

--- a/manager.spawnQueue.js
+++ b/manager.spawnQueue.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const logger = require("./logger");
 const scheduler = require('./scheduler');
 

--- a/role.reservist.js
+++ b/role.reservist.js
@@ -67,8 +67,19 @@ const roleReservist = {
       return;
     }
     const res = creep.reserveController(controller);
-    if (res === OK && controller.sign) {
-      controller.sign(creep, getRandomTyranidQuote());
+    if (res === OK) {
+      const quote = getRandomTyranidQuote();
+      if (typeof creep.signController === 'function') {
+        const currentSign = controller.sign;
+        const username = Memory.username || '';
+        if (
+          !currentSign ||
+          currentSign.username !== username ||
+          currentSign.text !== quote
+        ) {
+          creep.signController(controller, quote);
+        }
+      }
       _.set(Memory, ['rooms', roomName, 'reserveAttempts'], 0);
       stats.reservistSuccesses++;
     } else if (res !== OK) {

--- a/test/roleReservist.test.js
+++ b/test/roleReservist.test.js
@@ -1,9 +1,34 @@
 const { expect } = require('chai');
 const globals = require('./mocks/globals');
-const roleReservist = require('../role.reservist');
+const _ = require('lodash');
 const htm = require('../manager.htm');
 
+require('../utils.quotes');
+
 global.OK = 0;
+
+const quotesPath = require.resolve('../utils.quotes');
+
+function loadRoleReservist(quote = 'For the swarm!') {
+  const originalQuotesEntry = require.cache[quotesPath];
+  require.cache[quotesPath] = {
+    id: quotesPath,
+    filename: quotesPath,
+    loaded: true,
+    exports: { getRandomTyranidQuote: () => quote },
+  };
+
+  try {
+    delete require.cache[require.resolve('../role.reservist')];
+    return require('../role.reservist');
+  } finally {
+    if (originalQuotesEntry) {
+      require.cache[quotesPath] = originalQuotesEntry;
+    } else {
+      delete require.cache[quotesPath];
+    }
+  }
+}
 
 describe('role.reservist', function() {
   beforeEach(function() {
@@ -14,6 +39,7 @@ describe('role.reservist', function() {
   });
 
   it('queues retry when controller reserved by others', function() {
+    const roleReservist = loadRoleReservist();
     Game.rooms['W1N5'] = { name:'W1N5', controller:{ reservation:{ username:'enemy' }, my:false } };
     const creep = { name:'r1', memory:{ role:'reservist', targetRoom:'W1N5', homeRoom:'W1N1' }, room: Game.rooms['W1N5'], travelTo:()=>{}, suicide:()=>{ creep.died = true; } };
     roleReservist.run(creep);
@@ -24,9 +50,60 @@ describe('role.reservist', function() {
   });
 
   it('suicides when no controller present', function() {
+    const roleReservist = loadRoleReservist();
     Game.rooms['W1N5'] = { name:'W1N5', controller:null };
     const creep = { name:'r2', memory:{ role:'reservist', targetRoom:'W1N5' }, room: Game.rooms['W1N5'], travelTo:()=>{}, suicide:()=>{ creep.died = true; } };
     roleReservist.run(creep);
+    expect(creep.died).to.be.true;
+  });
+
+  it('signs controller when reservation succeeds with different signature', function() {
+    const roleReservist = loadRoleReservist('For the swarm!');
+    Memory.username = 'ally';
+    Memory.rooms = { W1N5: { reserveAttempts: 2 } };
+    Game.rooms['W1N5'] = { name:'W1N5', controller:{ sign:{ username:'other', text:'Old' } } };
+    const controller = Game.rooms['W1N5'].controller;
+    const creep = {
+      name:'r3',
+      memory:{ role:'reservist', targetRoom:'W1N5' },
+      room: Game.rooms['W1N5'],
+      travelTo:()=>{},
+      reserveController: () => OK,
+      signController: () => { creep.signed = true; },
+      suicide: () => { creep.died = true; },
+    };
+
+    roleReservist.run(creep);
+
+    expect(creep.signed).to.be.true;
+    expect(_.get(Memory, ['rooms', 'W1N5', 'reserveAttempts'])).to.equal(0);
+    const stats = Memory.stats.remoteRooms['W1N5'];
+    expect(stats.reservistSuccesses).to.equal(1);
+    expect(creep.died).to.be.true;
+  });
+
+  it('does not sign when controller already has matching signature', function() {
+    const roleReservist = loadRoleReservist('For the swarm!');
+    Memory.username = 'ally';
+    Memory.rooms = { W1N5: { reserveAttempts: 1 } };
+    Game.rooms['W1N5'] = { name:'W1N5', controller:{ sign:{ username:'ally', text:'For the swarm!' } } };
+    const controller = Game.rooms['W1N5'].controller;
+    const creep = {
+      name:'r4',
+      memory:{ role:'reservist', targetRoom:'W1N5' },
+      room: Game.rooms['W1N5'],
+      travelTo:()=>{},
+      reserveController: () => OK,
+      signController: () => { creep.signed = true; },
+      suicide: () => { creep.died = true; },
+    };
+
+    roleReservist.run(creep);
+
+    expect(creep.signed).to.not.be.true;
+    expect(_.get(Memory, ['rooms', 'W1N5', 'reserveAttempts'])).to.equal(0);
+    const stats = Memory.stats.remoteRooms['W1N5'];
+    expect(stats.reservistSuccesses).to.equal(1);
     expect(creep.died).to.be.true;
   });
 });

--- a/test/spawnLodashDependency.test.js
+++ b/test/spawnLodashDependency.test.js
@@ -1,0 +1,62 @@
+const { expect } = require('chai');
+const globals = require('./mocks/globals');
+
+describe('spawn module lodash dependencies', function () {
+  beforeEach(function () {
+    globals.resetGame();
+    globals.resetMemory({ stats: { logs: [], logCounts: {} } });
+    delete global._;
+    global.WORK = 'work';
+    global.MOVE = 'move';
+    global.HARVEST_POWER = 2;
+    global.FIND_SOURCES = 1;
+    global.BODYPART_COST = { work: 100, move: 50 };
+    global.OBSTACLE_OBJECT_TYPES = [];
+    global.LOOK_STRUCTURES = 1;
+    global.LOOK_CREEPS = 2;
+    global.TERRAIN_MASK_WALL = 1;
+  });
+
+  afterEach(function () {
+    delete global._;
+  });
+
+  it('spawns miners without relying on global lodash', function () {
+    delete require.cache[require.resolve('../manager.spawnQueue')];
+    delete require.cache[require.resolve('../manager.spawn')];
+
+    const spawnQueue = require('../manager.spawnQueue');
+    const spawnManager = require('../manager.spawn');
+
+    spawnQueue.queue = [];
+    Memory.nextSpawnRequestId = 0;
+    Memory.rooms = {
+      W1N1: {
+        miningPositions: {
+          src1: {
+            positions: {
+              pos1: { x: 10, y: 10, reserved: false },
+            },
+            distanceFromSpawn: 5,
+          },
+        },
+      },
+    };
+
+    const spawn = { id: 's1', pos: { getRangeTo: () => 4 }, room: { name: 'W1N1' } };
+    const room = {
+      name: 'W1N1',
+      find: (type) => (type === FIND_SOURCES ? [{ id: 'src1' }] : []),
+    };
+
+    Game.rooms['W1N1'] = room;
+    Game.getObjectById = () => ({ pos: { getRangeTo: () => 5 } });
+    Game.creeps = {};
+
+    const bodySize = spawnManager.spawnMiner(spawn, room, 300, null, true);
+
+    expect(bodySize).to.equal(2);
+    expect(spawnQueue.queue.length).to.equal(1);
+    expect(spawnQueue.queue[0].energyRequired).to.not.equal(undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- import lodash explicitly in the spawn manager and spawn queue modules so lodash helpers are always available
- update the reservist role to sign controllers via `creep.signController` only when a new signature is required
- add unit tests covering reservist signing flows and verifying spawn logic no longer depends on a global lodash

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4f9c03cb083278b4caa8e3a3cf82e