### PR TITLE
Retire legacy layout fallback and make executeLayout basePlan-only

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -264,9 +264,9 @@
 - [x] Generate multiple dynamic layout candidates with distance transform filters and weighted pre-scoring.
 - [x] Score anchors by controller/source/mineral/exit/terrain symmetry inputs and keep top candidates.
 - [ ] **LEGACY → Baseplanner P3/P5:** Emit lab/extension/tower/road layers as buildQueue-ready structure plans (statt separater Stamp-Pipeline).
-- [ ] **LEGACY → Baseplanner P5:** Teach `manager.building.executeLayout` to consume `basePlan.buildQueue` incl. reserved tiles, rampart overlays, and phased RCL unlocks.
+- [x] **LEGACY → Baseplanner P5:** `manager.building.executeLayout` consumes only `basePlan.buildQueue`; matrix fallback retired to avoid parallel legacy behavior.
 - [x] Persist selected layout + candidate evaluation data in `room.memory.layout` and expose debug overlays (`candidates`, `evaluation`).
-- [ ] **Migration:** Mirror `room.memory.layout` into `Memory.rooms[room].basePlan` until all consumers switched.
+- [ ] **Migration (Restpunkt):** Legacy `room.memory.layout` cleanup for visualization/debug can follow after bootstrap-base strategy (spawn relocation / dual-mode decision).
 
 ### 🐞 Debug Tools
 - [ ] `console.command('scan')` for room diagnostics

--- a/TyranidScreeps2.0.wiki/Baseplanner-Manual-Verification-Checklist.md
+++ b/TyranidScreeps2.0.wiki/Baseplanner-Manual-Verification-Checklist.md
@@ -140,7 +140,7 @@ Memory.rooms.W1N1.basePlan && Memory.rooms.W1N1.basePlan.buildQueue && Memory.ro
 ```
 
 **Soll:**
-- `manager.building.executeLayout` priorisiert `basePlan.buildQueue` vor legacy matrix.
+- `manager.building.executeLayout` arbeitet ausschließlich aus `basePlan.buildQueue` (kein Legacy-Matrix-Fallback).
 
 ---
 
@@ -171,3 +171,64 @@ Ein Algorithmus gilt als abgeschlossen, wenn:
 - es im Manual-Run reproduzierbar funktioniert,
 - die zugehörige Roadmap/Wiki-Markierung gesetzt wurde,
 - und Debug/Metadaten vorhanden sind, um Fehler später nachvollziehen zu können.
+
+
+---
+
+## 8) 10-Minuten Smoke-Test (kompakt)
+
+Wenn du nur schnell "grün/rot" prüfen willst:
+
+1. **Manual Mode aktivieren + Initialisierung:**
+```js
+visual.layoutManualMode(1)
+visual.layoutInitializePhase('W1N1', 4, 1)
+```
+**Erwartung:** Pipeline landet auf `paused_phase_9` oder `completed`, keine Exceptions.
+
+2. **BasePlan vorhanden + Validation ok/warn:**
+```js
+({
+  hasBasePlan: !!(Memory.rooms.W1N1.basePlan),
+  validation: Memory.rooms.W1N1.basePlan && Memory.rooms.W1N1.basePlan.validation
+})
+```
+**Erwartung:** `hasBasePlan === true`, Validation-Objekt vorhanden.
+
+3. **BuildQueue nicht leer + Next Build sichtbar:**
+```js
+Memory.rooms.W1N1.basePlan && Memory.rooms.W1N1.basePlan.buildQueue && Memory.rooms.W1N1.basePlan.buildQueue.slice(0,3)
+```
+**Erwartung:** Erste Einträge plausibel (spawn/roads/extensions je nach RCL).
+
+4. **HUD gegenprüfen:**
+- Base-Plan Block zeigt Status/Score/Validation/Next Build.
+- Keine widersprüchlichen Legacy-Indikatoren im HUD.
+
+Wenn diese 4 Punkte passen, ist der Kernpfad für den E2E-Lauf stabil.
+
+---
+
+## 9) Speziell beobachten: Bootstrap-Base → Ziel-Base Umbau
+
+Für deinen Zukunftsplan (Spawn steht anfangs "falsch", später Ziel-Layout):
+
+- **Achte auf diese Signale im Run:**
+  - Wird der erste Spawn im `basePlan.buildQueue` als persistentes Ziel geführt oder nur als Startzustand toleriert?
+  - Entsteht ab RCL 5/6 ein klarer Übergangspfad (zweiter Spawn + kritische Infrastruktur zuerst)?
+  - Bleibt die Queue nach RCL-Upgrades deterministisch (kein Flip-Flop bei Prioritäten)?
+
+- **Snapshot für Vergleich zwischen Strategien (Rush vs. Dual-Mode):**
+```js
+({
+  tick: Game.time,
+  rcl: Game.rooms.W1N1 && Game.rooms.W1N1.controller && Game.rooms.W1N1.controller.level,
+  spawns: (Game.rooms.W1N1 && Game.rooms.W1N1.find(FIND_MY_SPAWNS) || []).map(s => ({ id: s.id, x: s.pos.x, y: s.pos.y })),
+  nextBuilds: Memory.rooms.W1N1.basePlan && Memory.rooms.W1N1.basePlan.buildQueue
+    ? Memory.rooms.W1N1.basePlan.buildQueue.filter(i => !i.built).slice(0,8)
+    : [],
+  validation: Memory.rooms.W1N1.basePlan && Memory.rooms.W1N1.basePlan.validation
+})
+```
+
+Damit kannst du später sauber entscheiden, ob wir einen harten RCL5-Rush-Pfad oder einen temporären Dual-Mode einbauen.

--- a/manager.building.js
+++ b/manager.building.js
@@ -455,88 +455,46 @@ const buildingManager = {
   executeLayout: function (room) {
     const basePlan = room.memory && room.memory.basePlan;
     const baseQueue = basePlan && Array.isArray(basePlan.buildQueue) ? basePlan.buildQueue : null;
-    if (baseQueue && baseQueue.length > 0) {
-      const next = buildCompendium.getNextBuild(room, baseQueue);
-      if (!next || !next.pos || typeof next.pos.x !== 'number' || typeof next.pos.y !== 'number') {
-        return;
-      }
-
-      const x = Number(next.pos.x);
-      const y = Number(next.pos.y);
-      const type = next.type;
-      const hasStruct = room
-        .lookForAt(LOOK_STRUCTURES, x, y)
-        .some((s) => s.structureType === type);
-      const hasSite = room
-        .lookForAt(LOOK_CONSTRUCTION_SITES, x, y)
-        .some((s) => s.structureType === type);
-      if (hasStruct) {
-        next.built = true;
-        next.builtAt = Game.time;
-        return;
-      }
-      const queued = htm.taskExistsAt(htm.LEVELS.COLONY, room.name, 'BUILD_LAYOUT_PART', {
-        x,
-        y,
-        structureType: type,
-      });
-      if (!hasSite && !queued) {
-        htm.addColonyTask(
-          room.name,
-          'BUILD_LAYOUT_PART',
-          { x, y, structureType: type, rcl: next.rcl || 1, queueSource: 'basePlan' },
-          3,
-          200,
-          1,
-          'buildingManager',
-          { module: 'basePlanner' },
-        );
-      }
+    if (!baseQueue || baseQueue.length === 0) {
+      // Legacy matrix-driven queueing has been retired: only Baseplanner output is consumed.
       return;
     }
 
-    if (!room.memory.layout) return;
-    const priority = [
-      STRUCTURE_SPAWN,
-      STRUCTURE_EXTENSION,
-      STRUCTURE_TOWER,
-      STRUCTURE_STORAGE,
-      STRUCTURE_LINK,
-      STRUCTURE_ROAD,
-    ];
-    const matrix = room.memory.layout.matrix || {};
-    for (const type of priority) {
-      for (const x in matrix) {
-        for (const y in matrix[x]) {
-          const cell = matrix[x][y];
-          if (cell.structureType !== type) continue;
-          if (cell.rcl > room.controller.level) continue;
-          const hasStruct = room
-            .lookForAt(LOOK_STRUCTURES, x, y)
-            .some((s) => s.structureType === type);
-          const hasSite = room
-            .lookForAt(LOOK_CONSTRUCTION_SITES, x, y)
-            .some((s) => s.structureType === type);
-          const queued = htm.taskExistsAt(htm.LEVELS.COLONY, room.name, 'BUILD_LAYOUT_PART', {
-            x: Number(x),
-            y: Number(y),
-            structureType: type,
-          });
-          if (!hasStruct && !hasSite && !queued) {
-            htm.addColonyTask(
-              room.name,
-              'BUILD_LAYOUT_PART',
-              { x: Number(x), y: Number(y), structureType: type, rcl: cell.rcl },
-              3,
-              200,
-              1,
-              'buildingManager',
-              { module: 'layoutPlanner' },
-            );
-            return;
-          }
-        }
-      }
+    const next = buildCompendium.getNextBuild(room, baseQueue);
+    if (!next || !next.pos || typeof next.pos.x !== 'number' || typeof next.pos.y !== 'number') {
+      return;
+    }
+
+    const x = Number(next.pos.x);
+    const y = Number(next.pos.y);
+    const type = next.type;
+    const hasStruct = room
+      .lookForAt(LOOK_STRUCTURES, x, y)
+      .some((s) => s.structureType === type);
+    const hasSite = room
+      .lookForAt(LOOK_CONSTRUCTION_SITES, x, y)
+      .some((s) => s.structureType === type);
+    if (hasStruct) {
+      next.built = true;
+      next.builtAt = Game.time;
+      return;
+    }
+    const queued = htm.taskExistsAt(htm.LEVELS.COLONY, room.name, 'BUILD_LAYOUT_PART', {
+      x,
+      y,
+      structureType: type,
+    });
+    if (!hasSite && !queued) {
+      htm.addColonyTask(
+        room.name,
+        'BUILD_LAYOUT_PART',
+        { x, y, structureType: type, rcl: next.rcl || 1, queueSource: 'basePlan' },
+        3,
+        200,
+        1,
+        'buildingManager',
+        { module: 'basePlanner' },
+      );
     }
   },
 

--- a/test/executeLayout.test.js
+++ b/test/executeLayout.test.js
@@ -43,32 +43,51 @@ describe('buildingManager.executeLayout', function() {
     Game.rooms['W1N1'] = dummyRoom();
   });
 
-  it('queues BUILD_LAYOUT_PART task when missing', function() {
+  it('does not queue tasks from legacy layout matrix when basePlan is missing', function() {
     const room = Game.rooms['W1N1'];
     buildingManager.executeLayout(room);
     const container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
-    expect(container.tasks.length).to.equal(1);
-    const t = container.tasks[0];
-    expect(t.name).to.equal('BUILD_LAYOUT_PART');
-    expect(t.data).to.include({ x: 10, y: 10, structureType: STRUCTURE_EXTENSION });
+    expect(container).to.be.undefined;
   });
 
-  it('skips when RCL too low', function() {
+  it('ignores legacy layout matrix regardless of room RCL', function() {
     Game.rooms['W1N1'].controller.level = 1;
     buildingManager.executeLayout(Game.rooms['W1N1']);
     const container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
     expect(container).to.be.undefined;
   });
 
-  it('does not duplicate queued tasks', function() {
+  it('does not duplicate queued tasks for basePlan entries', function() {
     const room = Game.rooms['W1N1'];
+    Memory.rooms.W1N1.basePlan = {
+      buildQueue: [
+        {
+          type: STRUCTURE_EXTENSION,
+          pos: { x: 10, y: 10 },
+          rcl: 2,
+          priority: 1,
+          built: false,
+        },
+      ],
+    };
     buildingManager.executeLayout(room);
     buildingManager.executeLayout(room);
     const container = htm._getContainer(htm.LEVELS.COLONY, 'W1N1');
     expect(container.tasks.length).to.equal(1);
   });
 
-  it('ignores built structures', function() {
+  it('ignores built structures from basePlan entries', function() {
+    Memory.rooms.W1N1.basePlan = {
+      buildQueue: [
+        {
+          type: STRUCTURE_EXTENSION,
+          pos: { x: 10, y: 10 },
+          rcl: 2,
+          priority: 1,
+          built: false,
+        },
+      ],
+    };
     Game.rooms['W1N1'].lookForAt = (type) =>
       type === LOOK_STRUCTURES ? [{ structureType: STRUCTURE_EXTENSION }] : [];
     buildingManager.executeLayout(Game.rooms['W1N1']);


### PR DESCRIPTION
### Motivation
- Prevent parallel legacy and Baseplanner build-queueing to avoid inconsistent behavior during rollout. 
- Simplify `executeLayout` so the system consistently honors planner-generated `basePlan.buildQueue` as the single source of truth. 
- Update docs and verification checklist to make the new basePlan-only execution and quick smoke-tests explicit for manual E2E runs.

### Description
- Change `manager.building.executeLayout` to return early when no `basePlan.buildQueue` exists and to exclusively consume entries from `basePlan.buildQueue` instead of falling back to `room.memory.layout.matrix`. 
- Preserve existing deduping and built-detection logic while relocating it to operate only on Baseplanner entries via `buildCompendium.getNextBuild` and HTM task creation (`BUILD_LAYOUT_PART`). 
- Update `test/executeLayout.test.js` to assert that legacy matrix-driven queueing no longer produces tasks and to cover basePlan queue deduplication and built-marking. 
- Update `ROADMAP.md` and `TyranidScreeps2.0.wiki/Baseplanner-Manual-Verification-Checklist.md` to mark the migration step as completed and add an explicit 10-minute smoke-test and basePlan-only expectation.

### Testing
- Ran the full test suite with `npm test` and got all tests passing (`248 passing`).
- The modified test `test/executeLayout.test.js` was executed and passed as part of the suite confirming legacy-matrix suppression and basePlan behaviors. 
- No additional automated regressions were detected by the existing unit tests after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd022fb8c8327998a13979c8b91f2)